### PR TITLE
feat: Move policy/v1beta1 to policy/v1 for K8s 1.25+ compatability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ NAMESPACE_MINIO_OPERATOR ?= "minio-operator"
 NAMESPACE_DRUID ?= "druid"
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.2
+ENVTEST_K8S_VERSION = 1.25.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@
 - ```Druid``` CR belongs to api Group ```druid.apache.org``` and version ```v1alpha1```
 
 ### Notifications
-- Users may experience HPA issues with druid-operator with release 0.0.5, as described in the [issue]( https://github.com/druid-io/druid-operator/issues/160). 
+- Users may experience HPA issues with druid-operator with release 0.0.5, as described in the [issue]( https://github.com/druid-io/druid-operator/issues/160).
 - The latest release 0.0.6 has fixes for the above issue.
 - The operator has moved from HPA apiVersion autoscaling/v2beta1 to autoscaling/v2beta2 API users will need to update there HPA Specs according v2beta2 api in order to work with the latest druid-operator release.
 - Users may experience pvc deletion [issue](https://github.com/druid-io/druid-operator/issues/186) in release 0.0.6, this issue has been fixed in patch release 0.0.6.1.
 - druid-operator has moved Ingress apiVersion networking/v1beta1 to networking/v1. Users will need to update there Ingress Spec in the druid CR according networking/v1 syntax. In case users are using schema validated CRD, the CRD will also be needed to be updated.
+- druid-operator has moved PodDisruptionBudget apiVersion policy/v1beta1 to policy/v1. Users will need to update there Kubernetes versions to 1.21+ to use druid-operator-0.0.10+.
 
 ### Note
 Apache®, [Apache Druid, Druid®](https://druid.apache.org/) are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries. This project, druid-operator, is not an Apache Software Foundation project.

--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -7,7 +7,7 @@ import (
 	autoscalev2beta2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -208,7 +208,7 @@ type DruidNodeSpec struct {
 	PodLabels map[string]string `json:"podLabels,omitempty"`
 
 	// Optional
-	PodDisruptionBudgetSpec *v1beta1.PodDisruptionBudgetSpec `json:"podDisruptionBudgetSpec,omitempty"`
+	PodDisruptionBudgetSpec *policyv1.PodDisruptionBudgetSpec `json:"podDisruptionBudgetSpec,omitempty"`
 
 	// Required
 	RuntimeProperties string `json:"runtime.properties"`

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -223,7 +223,7 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 	}
 	if in.PodDisruptionBudgetSpec != nil {
 		in, out := &in.PodDisruptionBudgetSpec, &out.PodDisruptionBudgetSpec
-		*out = new(v1beta1.PodDisruptionBudgetSpec)
+		*out = new(policyv1.PodDisruptionBudgetSpec)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Services != nil {

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -4780,10 +4780,9 @@ spec:
                           x-kubernetes-int-or-string: true
                         selector:
                           description: Label query over pods whose evictions are managed
-                            by the disruption budget. A null selector selects no pods.
-                            An empty selector ({}) also selects no pods, which differs
-                            from standard behavior of selecting all pods. In policy/v1,
-                            an empty selector will select all pods in the namespace.
+                            by the disruption budget. A null selector will match no
+                            pods, while an empty ({}) selector will select all pods
+                            within the namespace.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -17,7 +17,7 @@ import (
 	"github.com/druid-io/druid-operator/apis/druid/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -254,7 +254,7 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid, emitEvents EventEm
 		if nodeSpec.PodDisruptionBudgetSpec != nil {
 			if _, err := sdkCreateOrUpdateAsNeeded(sdk,
 				func() (object, error) { return makePodDisruptionBudget(&nodeSpec, m, lm, nodeSpecUniqueStr) },
-				func() object { return &v1beta1.PodDisruptionBudget{} },
+				func() object { return &policyv1.PodDisruptionBudget{} },
 				alwaysTrueIsEqualsFn, noopUpdaterFn, m, podDisruptionBudgetNames, emitEvents); err != nil {
 				return err
 			}
@@ -344,9 +344,9 @@ func deployDruidCluster(sdk client.Client, m *v1alpha1.Druid, emitEvents EventEm
 	sort.Strings(updatedStatus.Ingress)
 
 	updatedStatus.PodDisruptionBudgets = deleteUnusedResources(sdk, m, podDisruptionBudgetNames, ls,
-		func() objectList { return &v1beta1.PodDisruptionBudgetList{} },
+		func() objectList { return &policyv1.PodDisruptionBudgetList{} },
 		func(listObj runtime.Object) []object {
-			items := listObj.(*v1beta1.PodDisruptionBudgetList).Items
+			items := listObj.(*policyv1.PodDisruptionBudgetList).Items
 			result := make([]object, len(items))
 			for i := 0; i < len(items); i++ {
 				result[i] = &items[i]
@@ -1366,13 +1366,13 @@ func updateDefaultPortInProbe(probe *v1.Probe, defaultPort int32) *v1.Probe {
 	return probe
 }
 
-func makePodDisruptionBudget(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[string]string, nodeSpecUniqueStr string) (*v1beta1.PodDisruptionBudget, error) {
+func makePodDisruptionBudget(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[string]string, nodeSpecUniqueStr string) (*policyv1.PodDisruptionBudget, error) {
 	pdbSpec := *nodeSpec.PodDisruptionBudgetSpec
 	pdbSpec.Selector = &metav1.LabelSelector{MatchLabels: ls}
 
-	pdb := &v1beta1.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "policy/v1beta1",
+			APIVersion: "policy/v1",
 			Kind:       "PodDisruptionBudget",
 		},
 

--- a/controllers/druid/handler_test.go
+++ b/controllers/druid/handler_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ghodss/yaml"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 )
 
 func TestMakeStatefulSetForBroker(t *testing.T) {
@@ -67,7 +67,7 @@ func TestMakePodDisruptionBudgetForBroker(t *testing.T) {
 	actual, _ := makePodDisruptionBudget(&nodeSpec, clusterSpec, makeLabelsForNodeSpec(&nodeSpec, clusterSpec, clusterSpec.Name, nodeSpecUniqueStr), nodeSpecUniqueStr)
 	addHashToObject(actual)
 
-	expected := new(v1beta1.PodDisruptionBudget)
+	expected := new(policyv1.PodDisruptionBudget)
 	readAndUnmarshallResource("testdata/broker-pod-disruption-budget.yaml", &expected, t)
 
 	assertEquals(expected, actual, t)

--- a/controllers/druid/testdata/broker-pod-disruption-budget.yaml
+++ b/controllers/druid/testdata/broker-pod-disruption-budget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
@@ -9,7 +9,7 @@ metadata:
   name: druid-druid-test-brokers
   namespace: test-namespace
   annotations:
-    druidOpResourceHash: PSUil0VZr4P6YHR8+EGWPiCSiXg=
+    druidOpResourceHash: DmYcIjqpkJs9KWZ/tfHgHPBJ/wo=
 spec:
   maxUnavailable: 1
   selector:

--- a/deploy/crds/druid.apache.org_druids.yaml
+++ b/deploy/crds/druid.apache.org_druids.yaml
@@ -4780,10 +4780,9 @@ spec:
                           x-kubernetes-int-or-string: true
                         selector:
                           description: Label query over pods whose evictions are managed
-                            by the disruption budget. A null selector selects no pods.
-                            An empty selector ({}) also selects no pods, which differs
-                            from standard behavior of selecting all pods. In policy/v1,
-                            an empty selector will select all pods in the namespace.
+                            by the disruption budget. A null selector will match no
+                            pods, while an empty ({}) selector will select all pods
+                            within the namespace.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector


### PR DESCRIPTION
Fixes #5

### Description
This PR moves `policy/v1beta1` to `policy/v1` for the PodDisruptionBudget.  `policy/v1beta1` was deprecated in K8s 1.21 and removed in 1.25.  It should be noted that this PR will make K8s <1.21 unsupported.

This PR has:
- [X] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [X] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `PodDisruptionBudget`