### PR TITLE
helm: Keep CRD by default so druid clusters are not automatically rem…

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    {{- if .Values.crd.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
   creationTimestamp: null
   name: druids.druid.apache.org
 spec:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -79,3 +79,4 @@ affinity: {}
 
 crd:
   enabled: true
+  keep: true


### PR DESCRIPTION
Fixes #6 

### Description
Currently if the druid operator is installed with CRDs via the helm chart and then the helm chart is uninstalled then the CRDs are removed and all druid clusters would be destroyed.
This PR defaults to keeping the CRDs on helm chart uninstall and allows the user to configure the option to not.

This PR has:
- [X] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [X] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added documentation for new or modified features or behaviors.

##### Key changed/added files in this PR
 * `CRDs`
