### PR TITLE
fix: set maxSurge and maxUnavailable to 25% by default for deployment

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -273,10 +273,10 @@ type DruidNodeSpec struct {
 	// Optional: By default it is set to "parallel"
 	PodManagementPolicy appsv1.PodManagementPolicyType `json:"podManagementPolicy,omitempty"`
 
-	// Optional: maxSurge for deployment object, only applicable if kind=Deployment
+	// Optional: maxSurge for deployment object, only applicable if kind=Deployment, by default set to 25%
 	MaxSurge *int32 `json:"maxSurge,omitempty"`
 
-	// Optional: maxUnavailable for deployment object, only applicable if kind=Deployment
+	// Optional: maxUnavailable for deployment object, only applicable if kind=Deployment, by default set to 25%
 	MaxUnavailable *int32 `json:"maxUnavailable,omitempty"`
 
 	// Optional

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -4417,12 +4417,12 @@ spec:
                       type: string
                     maxSurge:
                       description: 'Optional: maxSurge for deployment object, only
-                        applicable if kind=Deployment'
+                        applicable if kind=Deployment, by default set to 25%'
                       format: int32
                       type: integer
                     maxUnavailable:
                       description: 'Optional: maxUnavailable for deployment object,
-                        only applicable if kind=Deployment'
+                        only applicable if kind=Deployment, by default set to 25%'
                       format: int32
                       type: integer
                     nodeConfigMountPath:

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1190,14 +1190,7 @@ func getRollingUpdateStrategy(nodeSpec *v1alpha1.DruidNodeSpec) *appsv1.RollingU
 			},
 		}
 	}
-	return &appsv1.RollingUpdateDeployment{
-		MaxUnavailable: &intstr.IntOrString{
-			IntVal: int32(25),
-		},
-		MaxSurge: &intstr.IntOrString{
-			IntVal: int32(25),
-		},
-	}
+	return &appsv1.RollingUpdateDeployment{}
 
 }
 

--- a/controllers/druid/testdata/broker-deployment.yaml
+++ b/controllers/druid/testdata/broker-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     nodeSpecUniqueStr: druid-druid-test-brokers
     component: broker
   annotations:
-    druidOpResourceHash: rjo/DfrcRi1LUUEhdkBJch19eDs=
+    druidOpResourceHash: du7ks4I5YTmInUUcbietAP8beVI=
 spec:
   replicas: 2
   selector:
@@ -19,9 +19,7 @@ spec:
       nodeSpecUniqueStr: druid-druid-test-brokers
       component: broker
   strategy:
-   rollingUpdate:
-     maxSurge: 25
-     maxUnavailable: 25
+   rollingUpdate: {}
    type: RollingUpdate
   template:
     metadata:

--- a/deploy/crds/druid.apache.org_druids.yaml
+++ b/deploy/crds/druid.apache.org_druids.yaml
@@ -4417,12 +4417,12 @@ spec:
                       type: string
                     maxSurge:
                       description: 'Optional: maxSurge for deployment object, only
-                        applicable if kind=Deployment'
+                        applicable if kind=Deployment, by default set to 25%'
                       format: int32
                       type: integer
                     maxUnavailable:
                       description: 'Optional: maxUnavailable for deployment object,
-                        only applicable if kind=Deployment'
+                        only applicable if kind=Deployment, by default set to 25%'
                       format: int32
                       type: integer
                     nodeConfigMountPath:


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Druid operator set deployment rollingUpdateStrategy to `maxSurge: 25` and `maxUnavailable: 25`
I think the default values should match the default value of the rollingUpdateStrategy (25% for both fields)  

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `controllers/druid/handler.go`
 * `apis/druid/v1alpha1/druid_types.go`

