### PR TITLE
chore(docs): add kubernetes compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@
 - Join Kubernetes slack and join [druid-operator](https://kubernetes.slack.com/archives/C04F4M6HT2L)
 
 ### Talks and Blogs on Druid Operator
+
 - [Dok Community](https://www.youtube.com/live/X4A3lWJRGHk?feature=share)
 - [Druid Summit](https://youtu.be/UqPrttXRBDg)
 - [Druid Operator Blog](https://www.cloudnatively.com/apache-druid-on-kubernetes/)
 - [Druid On K8s Without ZK](https://youtu.be/TRYOvkz5Wuw)
 
 ### Supported CR
+
 - The operator supports CR of type ```Druid```.
 - ```Druid``` CR belongs to api Group ```druid.apache.org``` and version ```v1alpha1```
 
@@ -28,13 +30,23 @@
 ![Druid Operator](docs/images/druid-operator.png?raw=true "Druid Operator")
 
 ### Notifications
+
 - Users may experience HPA issues with druid-operator with release 0.0.5, as described in the [issue](https://github.com/druid-io/druid-operator/issues/160).
 - The latest release 0.0.6 has fixes for the above issue.
 - The operator has moved from HPA apiVersion autoscaling/v2beta1 to autoscaling/v2beta2 API users will need to update there HPA Specs according v2beta2 api in order to work with the latest druid-operator release.
 - Users may experience pvc deletion [issue](https://github.com/druid-io/druid-operator/issues/186) in release 0.0.6, this issue has been fixed in patch release 0.0.6.1.
 - druid-operator has moved Ingress apiVersion networking/v1beta1 to networking/v1. Users will need to update there Ingress Spec in the druid CR according networking/v1 syntax. In case users are using schema validated CRD, the CRD will also be needed to be updated.
 - druid-operator has moved PodDisruptionBudget apiVersion policy/v1beta1 to policy/v1. Users will need to update there Kubernetes versions to 1.21+ to use druid-operator tag 0.0.9+.
-- The latest release for druid-operator is v1.0.0, this release is compatible with k8s version 1.25. HPA API is kept to version v2beta2. 
+- The latest release for druid-operator is v1.0.0, this release is compatible with k8s version 1.25. HPA API is kept to version v2beta2.
+
+### Kubernetes version compatibility
+
+| druid-operator | 0.0.9 | v1.0.0 |
+| :------------- | :-------------: | :-----: |
+| kubernetes <= 1.20 | :x:| :x: |
+| kubernetes == 1.21 | :white_check_mark:| :x: |
+| kubernetes >= 1.22 and < 1.25 | :white_check_mark: | :white_check_mark: |
+| kubernetes > 1.25 | :x: | :white_check_mark: |
 
 ### Contributors
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

I 'm trying to improve the documentation.
It can be nice for users to have the Kubernetes compatibility and 2 or 3 version of the operator on the readme

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `README.md`
