### PR TITLE
Pass context from Reconcile function to inside functions

### DIFF
--- a/controllers/druid/druid_controller.go
+++ b/controllers/druid/druid_controller.go
@@ -55,8 +55,6 @@ func NewDruidReconciler(mgr ctrl.Manager) *DruidReconciler {
 func (r *DruidReconciler) Reconcile(ctx context.Context, request reconcile.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("druid", request.NamespacedName)
 
-	// your logic here
-
 	// Fetch the Druid instance
 	instance := &druidv1alpha1.Druid{}
 	err := r.Get(ctx, request.NamespacedName, instance)
@@ -74,7 +72,7 @@ func (r *DruidReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 	// Intialize Emit Events
 	var emitEvent EventEmitter = EmitEventFuncs{r.Recorder}
 
-	if err := deployDruidCluster(r.Client, instance, emitEvent); err != nil {
+	if err := deployDruidCluster(ctx, r.Client, instance, emitEvent); err != nil {
 		return ctrl.Result{}, err
 	} else {
 		return ctrl.Result{RequeueAfter: r.ReconcileWait}, nil


### PR DESCRIPTION
Fixes #43 

### Description

Instead of using `context.TODO()` which is used for development, we will pass the Reconcile function context is describe in [Kubebuilder's documentation](https://book.kubebuilder.io/cronjob-tutorial/controller-overview.html#:~:text=The%20context%20is%20used%20to%20allow%20cancelation%20of%20requests%2C%20and%20potentially%20things%20like%20tracing.%20It%E2%80%99s%20the%20first%20argument%20to%20all%20client%20methods.%20The%20Background%20context%20is%20just%20a%20basic%20context%20without%20any%20extra%20data%20or%20timing%20restrictions.)

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `controllers/druid/druid_controller.go`
 * `controllers/druid/handler.go`