### PR TITLE
fix: kubernetes compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@
 
 ### Kubernetes version compatibility
 
-| druid-operator | 0.0.9 | v1.0.0 |
-| :------------- | :-------------: | :-----: |
-| kubernetes <= 1.20 | :x:| :x: |
-| kubernetes == 1.21 | :white_check_mark:| :x: |
-| kubernetes >= 1.22 and < 1.25 | :white_check_mark: | :white_check_mark: |
-| kubernetes > 1.25 | :x: | :white_check_mark: |
+| druid-operator | 0.0.9 | v1.0.0 | v1.1.0 |
+| :------------- | :-------------: | :-----: | :---: |
+| kubernetes <= 1.20 | :x:| :x: | :x: |
+| kubernetes == 1.21 | :white_check_mark:| :x: | :x: |
+| kubernetes >= 1.22 and < 1.25 | :white_check_mark: | :white_check_mark: | :x: |
+| kubernetes > 1.25 | :x: | :x: | :white_check_mark: |
 
 ### Contributors
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

linked to #48 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

Update compatibility matrix as HPA/v2beta2 is not present anymore in 1.26