### PR TITLE
feat: added support for hdfs-site.xml and core-site.xml configs

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -233,6 +233,12 @@ type DruidSpec struct {
 	// Custom Dimension Map Path for statsd emitter
 	// +optional
 	DimensionsMapPath string `json:"metricDimensions.json,omitempty"`
+	// HDFS common config
+	// +optional
+	HdfsSite string `json:"hdfs-site.xml,omitempty"`
+
+	// +optional
+	CoreSite string `json:"core-site.xml,omitempty"`
 }
 
 type DruidNodeSpec struct {

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -1483,6 +1483,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              core-site.xml:
+                type: string
               deepStorage:
                 properties:
                   spec:
@@ -1651,6 +1653,9 @@ spec:
                 type: array
               forceDeleteStsPodOnError:
                 type: boolean
+              hdfs-site.xml:
+                description: HDFS common config
+                type: string
               ignored:
                 default: false
                 description: 'Ignored is now deprecated API. In order to avoid reconciliation

--- a/config/crd/bases/druid.apache.org_druids.yaml
+++ b/config/crd/bases/druid.apache.org_druids.yaml
@@ -1483,6 +1483,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              core-site.xml:
+                type: string
               deepStorage:
                 properties:
                   spec:
@@ -1651,6 +1653,9 @@ spec:
                 type: array
               forceDeleteStsPodOnError:
                 type: boolean
+              hdfs-site.xml:
+                description: HDFS common config
+                type: string
               ignored:
                 default: false
                 description: 'Ignored is now deprecated API. In order to avoid reconciliation

--- a/config/druid.apache.org_druids.yaml
+++ b/config/druid.apache.org_druids.yaml
@@ -1483,6 +1483,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              core-site.xml:
+                type: string
               deepStorage:
                 properties:
                   spec:
@@ -1651,6 +1653,9 @@ spec:
                 type: array
               forceDeleteStsPodOnError:
                 type: boolean
+              hdfs-site.xml:
+                description: HDFS common config
+                type: string
               ignored:
                 default: false
                 description: 'Ignored is now deprecated API. In order to avoid reconciliation

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -951,7 +951,12 @@ func makeCommonConfigMap(m *v1alpha1.Druid, ls map[string]string) (*v1.ConfigMap
 	if m.Spec.DimensionsMapPath != "" {
 		data["metricDimensions.json"] = m.Spec.DimensionsMapPath
 	}
-
+	if m.Spec.HdfsSite != "" {
+		data["hdfs-site.xml"] = m.Spec.HdfsSite
+	}
+	if m.Spec.CoreSite != "" {
+		data["core-site.xml"] = m.Spec.CoreSite
+	}
 	cfg, err := makeConfigMap(
 		fmt.Sprintf("%s-druid-common-config", m.ObjectMeta.Name),
 		m.Namespace,

--- a/controllers/druid/testdata/druid-smoke-test-cluster.yaml
+++ b/controllers/druid/testdata/druid-smoke-test-cluster.yaml
@@ -27,6 +27,30 @@ spec:
         type: ClusterIP
         clusterIP: None
   commonConfigMountPath: "/opt/druid/conf/druid/cluster/_common"
+  hdfs-site.xml: |-
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <Configuration>
+      <Property>
+        <Name>dfs.replication</Name>
+        <Value>1</Value>
+      </Property>
+      <Property>
+        <Name>dfs.client.use.datanode.hostname</Name>
+        <Value>true</Value>
+      </Property>
+      <Property>
+        <Name>dfs.datanode.use.datanode.hostname</Name>
+        <Value>true</Value>
+      </Property>
+    </Configuration>
+  core-site.xml: |-
+    <?xml version="1.0" encoding="UTF-8" ?>
+    <Configuration>
+      <Property>
+        <Name>fs.defaultFS</Name>
+        <Value>hdfs://HOSTNAME:9000</Value>
+      </Property>
+    </Configuration>
   jvm.options: |-
     -server
     -XX:MaxDirectMemorySize=10240g
@@ -206,7 +230,7 @@ spec:
         tls:
         - hosts:
           - broker.myhostname.com
-      secretName: tls-broker-druid-cluster
+          secretName: tls-broker-druid-cluster
       runtime.properties: |
         druid.service=druid/router
 


### PR DESCRIPTION
Fixes #37 .

### Description

Added support for hdfs-site.xml and core-site.xml common config files which will be mounted under /opt/druid/conf/druid/cluster/_common.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `apis/druid/v1alpha1/druid_types.go`
 * `chart/templates/crds/druid.apache.org_druids.yaml`
 * `config/crd/bases/druid.apache.org_druids.yaml`
 * `config/druid.apache.org_druids.yamll`
 * `controllers/druid/handler.go`
 * `controllers/druid/testdata/druid-smoke-test-cluster.yaml`


