### PR TITLE
Delay removal of orphanPVC to avoid the removal of PVC in use

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -509,8 +509,6 @@ func deleteOrphanPVC(ctx context.Context, sdk client.Client, drd *v1alpha1.Druid
 					err = setPVCLabels(ctx, sdk, drd, emitEvents, pvcList[i], getPvcLabels, true)
 					if err != nil {
 						return err
-					} else {
-						// do nothing
 					}
 				}
 			} else {
@@ -523,8 +521,6 @@ func deleteOrphanPVC(ctx context.Context, sdk client.Client, drd *v1alpha1.Druid
 					err = setPVCLabels(ctx, sdk, drd, emitEvents, pvcList[i], getPvcLabels, false)
 					if err != nil {
 						return err
-					} else {
-						// do nothing
 					}
 				}
 			}

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -518,11 +518,11 @@ func deleteOrphanPVC(ctx context.Context, sdk client.Client, drd *v1alpha1.Druid
 						}
 					} else {
 						// wait for 60s
-						msg := fmt.Sprintf("pvc [%s:%s] mark to be deleted after %ds", pvcList[i].GetName(), drd.Namespace, timeDiff)
+						msg := fmt.Sprintf("pvc [%s:%s] marked to be deleted after %ds", pvcList[i].GetName(), drd.Namespace, timeDiff)
 						logger.Info(msg, "name", drd.Name, "namespace", drd.Namespace)
 					}
 				} else {
-					// set labels when pvc comes for deletion for the deletion, then wait for 60s to delete it
+					// set labels when pvc comes for deletion for the first time
 					getPvcLabels := pvc.GetLabels()
 					getPvcLabels["toBeDeleted"] = "yes"
 					getPvcLabels["deletionTimestamp"] = strconv.FormatInt(time.Now().Unix(), 10)
@@ -532,7 +532,7 @@ func deleteOrphanPVC(ctx context.Context, sdk client.Client, drd *v1alpha1.Druid
 					if err != nil {
 						return err
 					} else {
-						msg := fmt.Sprintf("pvc mark to be deleted, added labels %s and %s successfully [%s]", "toBeDeleted", "deletionTimestamp", pvc.GetName())
+						msg := fmt.Sprintf("marked pvc for deletion , added labels %s and %s successfully [%s]", "toBeDeleted", "deletionTimestamp", pvc.GetName())
 						logger.Info(msg, "name", drd.Name, "namespace", drd.Namespace)
 					}
 				}
@@ -548,7 +548,7 @@ func deleteOrphanPVC(ctx context.Context, sdk client.Client, drd *v1alpha1.Druid
 					if err != nil {
 						return err
 					} else {
-						msg := fmt.Sprintf("Deleted labels %s and %s successfully in pvc [%s]", "toBeDeleted", "deletionTimestamp", pvc.GetName())
+						msg := fmt.Sprintf("unmarked pvc for deletion, removed labels %s and %s successfully in pvc [%s]", "toBeDeleted", "deletionTimestamp", pvc.GetName())
 						logger.Info(msg, "name", drd.Name, "namespace", drd.Namespace)
 					}
 				}

--- a/controllers/druid/util.go
+++ b/controllers/druid/util.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func firstNonEmptyStr(s1 string, s2 string) string {
@@ -76,4 +77,13 @@ func Str2Int(s string) int {
 		return 1
 	}
 	return i
+}
+
+// to find the time difference between two epoch times
+func timeDifference(epochTime1, epochTime2 int64) int64 {
+	t1 := time.Unix(epochTime1, 0)
+	t2 := time.Unix(epochTime2, 0)
+
+	diff := time.Duration(t2.Sub(t1))
+	return int64(diff.Seconds())
 }


### PR DESCRIPTION
Fixes #32 

### Description

Possibly a race condition is causing removal of PVC in use.

The solution in the PR: Added two labels `toBeDeleted` and `deletionTimestamp` to mark the pvc for deletion. Do not delete the pvc right away, wait for 60s to delete it and avoid the race condition.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `controllers/druid/handler.go`
 * `controllers/druid/util.go`
