### PR TITLE
feat: set default probe for each druid components

### DIFF
--- a/controllers/druid/testdata/broker-deployment.yaml
+++ b/controllers/druid/testdata/broker-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     nodeSpecUniqueStr: druid-druid-test-brokers
     component: broker
   annotations:
-    druidOpResourceHash: du7ks4I5YTmInUUcbietAP8beVI=
+    druidOpResourceHash: BWc+znXyJdW5P9aPZqT7929PtgA=
 spec:
   replicas: 2
   selector:
@@ -19,8 +19,8 @@ spec:
       nodeSpecUniqueStr: druid-druid-test-brokers
       component: broker
   strategy:
-   rollingUpdate: {}
-   type: RollingUpdate
+    rollingUpdate: {}
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -35,49 +35,58 @@ spec:
       tolerations: []
       affinity: {}
       containers:
-      - command:
-        - bin/run-druid.sh
-        - broker
-        image: himanshu01/druid:druid-0.12.0-1
-        name: druid-druid-test-brokers
-        env:
-          - name : configMapSHA
-            value : blah
-        ports:
-        - containerPort: 8083
-          name: random
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: 8080
-        livenessProbe:
-          httpGet:
-            path: /status
-            port: 8080
-        resources:
-          limits:
-            cpu: "4"
-            memory: 2Gi
-          requests:
-            cpu: "4"
-            memory: 2Gi
-        volumeMounts:
-        - mountPath: /druid/conf/druid/_common
-          readOnly: true
-          name: common-config-volume
-        - mountPath: /druid/conf/druid/broker
-          readOnly: true
-          name: nodetype-config-volume
-        - mountPath: /druid/data
-          readOnly: true
-          name: data-volume
+        - command:
+            - bin/run-druid.sh
+            - broker
+          image: himanshu01/druid:druid-0.12.0-1
+          name: druid-druid-test-brokers
+          env:
+            - name: configMapSHA
+              value: blah
+          ports:
+            - containerPort: 8083
+              name: random
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+          startupProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /druid/broker/v1/readiness
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "4"
+              memory: 2Gi
+            requests:
+              cpu: "4"
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /druid/conf/druid/_common
+              readOnly: true
+              name: common-config-volume
+            - mountPath: /druid/conf/druid/broker
+              readOnly: true
+              name: nodetype-config-volume
+            - mountPath: /druid/data
+              readOnly: true
+              name: data-volume
       securityContext:
         fsGroup: 107
         runAsUser: 106
       volumes:
-      - configMap:
-          name: druid-test-druid-common-config
-        name: common-config-volume
-      - configMap:
-          name: druid-druid-test-brokers-config
-        name: nodetype-config-volume
+        - configMap:
+            name: druid-test-druid-common-config
+          name: common-config-volume
+        - configMap:
+            name: druid-druid-test-brokers-config
+          name: nodetype-config-volume

--- a/controllers/druid/testdata/broker-statefulset-sidecar.yaml
+++ b/controllers/druid/testdata/broker-statefulset-sidecar.yaml
@@ -9,7 +9,7 @@ metadata:
     nodeSpecUniqueStr: druid-druid-test-brokers
     component: broker
   annotations:
-    druidOpResourceHash: qItQSuF2PU0ZPa2ZFyj3DOa7qNc=
+    druidOpResourceHash: Q+HvxwhK3mmgnAm97GEQpeWbDv0=
 spec:
   podManagementPolicy: Parallel
   replicas: 2
@@ -40,8 +40,8 @@ spec:
           image: apache/druid:0.22.1
           name: druid-druid-test-brokers
           env:
-            - name : configMapSHA
-              value : blah
+            - name: configMapSHA
+              value: blah
           ports:
             - containerPort: 8083
               name: random
@@ -53,6 +53,15 @@ spec:
             httpGet:
               path: /status
               port: 8080
+          startupProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /druid/broker/v1/readiness
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
           resources:
             limits:
               cpu: "4"
@@ -108,12 +117,12 @@ spec:
             name: druid-druid-test-brokers-config
           name: nodetype-config-volume
   volumeClaimTemplates:
-  - metadata:
-      name: data-volume
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: 2Gi
-      storageClassName: gp2
+    - metadata:
+        name: data-volume
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+        storageClassName: gp2

--- a/controllers/druid/testdata/broker-statefulset.yaml
+++ b/controllers/druid/testdata/broker-statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     nodeSpecUniqueStr: druid-druid-test-brokers
     component: broker
   annotations:
-    druidOpResourceHash: gfGJ6aviJkM512x1ltsWOty2y5M=
+    druidOpResourceHash: nm2DDc54TuljVernCmU6WJ6Lmi4=
 spec:
   podManagementPolicy: Parallel
   replicas: 2
@@ -34,59 +34,68 @@ spec:
       tolerations: []
       affinity: {}
       containers:
-      - command:
-        - bin/run-druid.sh
-        - broker
-        image: himanshu01/druid:druid-0.12.0-1
-        name: druid-druid-test-brokers
-        env:
-          - name : configMapSHA
-            value : blah
-        ports:
-        - containerPort: 8083
-          name: random
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: 8080
-        livenessProbe:
-          httpGet:
-            path: /status
-            port: 8080
-        resources:
-          limits:
-            cpu: "4"
-            memory: 2Gi
-          requests:
-            cpu: "4"
-            memory: 2Gi
-        volumeMounts:
-        - mountPath: /druid/conf/druid/_common
-          readOnly: true
-          name: common-config-volume
-        - mountPath: /druid/conf/druid/broker
-          readOnly: true
-          name: nodetype-config-volume
-        - mountPath: /druid/data
-          readOnly: true
-          name: data-volume
+        - command:
+            - bin/run-druid.sh
+            - broker
+          image: himanshu01/druid:druid-0.12.0-1
+          name: druid-druid-test-brokers
+          env:
+            - name: configMapSHA
+              value: blah
+          ports:
+            - containerPort: 8083
+              name: random
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+          startupProbe:
+            failureThreshold: 20
+            httpGet:
+              path: /druid/broker/v1/readiness
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: "4"
+              memory: 2Gi
+            requests:
+              cpu: "4"
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /druid/conf/druid/_common
+              readOnly: true
+              name: common-config-volume
+            - mountPath: /druid/conf/druid/broker
+              readOnly: true
+              name: nodetype-config-volume
+            - mountPath: /druid/data
+              readOnly: true
+              name: data-volume
       securityContext:
         fsGroup: 107
         runAsUser: 106
       volumes:
-      - configMap:
-          name: druid-test-druid-common-config
-        name: common-config-volume
-      - configMap:
-          name: druid-druid-test-brokers-config
-        name: nodetype-config-volume
+        - configMap:
+            name: druid-test-druid-common-config
+          name: common-config-volume
+        - configMap:
+            name: druid-druid-test-brokers-config
+          name: nodetype-config-volume
   volumeClaimTemplates:
-  - metadata:
-      name: data-volume
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 2Gi
-      storageClassName: gp2
+    - metadata:
+        name: data-volume
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+        storageClassName: gp2

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,14 +1,16 @@
 # Features
 
-* [Deny List in Operator](#Deny-List-in-Operator)
-* [Reconcile Time in Operator](#Reconcile-Time-in-Operator)
-* [Finalizer in Druid CR](#Finalizer-in-Druid-CR)
-* [Deletetion of Orphan PVC's](#Deletetion-of-Orphan-PVC's)
-* [Rolling Deploy](#Rolling-Deploy)
-* [Force Delete of Sts Pods](#Force-Delete-of-Sts-Pods)
-* [Scaling of Druid Nodes](#Scaling-of-Druid-Nodes)
-* [Volume Expansion of Druid Nodes Running As StatefulSets](#Scaling-of-Druid-Nodes)
-* [Add Additional Containers in Druid Nodes](#Add-Additional-Containers-in-Druid-Nodes)
+- [Features](#features)
+  - [Deny List in Operator](#deny-list-in-operator)
+  - [Reconcile Time in Operator](#reconcile-time-in-operator)
+  - [Finalizer in Druid CR](#finalizer-in-druid-cr)
+  - [Deletetion of Orphan PVC's](#deletetion-of-orphan-pvcs)
+  - [Rolling Deploy](#rolling-deploy)
+  - [Force Delete of Sts Pods](#force-delete-of-sts-pods)
+  - [Scaling of Druid Nodes](#scaling-of-druid-nodes)
+  - [Volume Expansion of Druid Nodes Running As StatefulSets](#volume-expansion-of-druid-nodes-running-as-statefulsets)
+  - [Add Additional Containers in Druid Nodes](#add-additional-containers-in-druid-nodes)
+  - [Setup default probe by default](#setup-default-probe-by-default)
 
 
 ## Deny List in Operator
@@ -67,3 +69,116 @@
 - This can be used for init containers or sidecars or proxies etc. 
 - To enable this features users just need to add a new container to the container list 
 - This is scoped at cluster scope only, which means that additional container will be common to all the nodes
+
+## Setup default probe by default
+
+The operator create deployments and statefullset with a default set of probes for each druid components.
+Theses probes are overrided if you specify a global or specific probe in the druid resource.
+All the probes definitions are documented bellow:
+
+<details>
+
+<summary>Coordinator, Overlord, Middlemanager, Router and Indexer probes</summary>
+
+```yaml
+  livenessProbe:
+    failureThreshold: 10
+    httpGet:
+      path: /status/health
+      port: $druid.port
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+  readinessProbe:
+    failureThreshold: 10
+    httpGet:
+      path: /status/health
+      port: $druid.port
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+  startupProbe:
+    failureThreshold: 10
+    httpGet:
+      path: /status/health
+      port: $druid.port
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+```
+
+</details>
+
+<details>
+
+<summary>Broker probes </summary>
+
+  ```yaml
+      livenessProbe:
+        failureThreshold: 10
+        httpGet:
+          path: /status/health
+          port: $druid.port
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 5
+      readinessProbe:
+        failureThreshold: 20
+        httpGet:
+          path: /druid/broker/v1/readiness
+          port: $druid.port
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 5
+      startupProbe:
+        failureThreshold: 20
+        httpGet:
+          path: /druid/broker/v1/readiness
+          port: $druid.port
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 5
+  ```
+</details>
+
+<details>
+
+<summary>Historical probes</summary>
+
+```yaml
+  livenessProbe:
+    failureThreshold: 10
+    httpGet:
+      path: /status/health
+      port: $druid.port
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+  readinessProbe:
+    failureThreshold: 20
+    httpGet:
+      path: /druid/historical/v1/loadstatus
+      port: $druid.port
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+  startupProbe:
+    failureThreshold: 20
+    httpGet:
+      path: /druid/historical/v1/loadstatus
+      port: $druid.port
+    initialDelaySeconds: 180
+    periodSeconds: 30
+    successThreshold: 1
+    timeoutSeconds: 10
+```
+
+</details>


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #55 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Add function to setup default probe properly for each node types 

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
