### PR TITLE
secure metadata storage example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -304,3 +304,31 @@
         - -instance=instance
         - -logFiles=logFiles
 ```
+
+## Secure Metadata Storage password
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metadata-storage-password
+  namespace: <NAMESPACE>
+type: Opaque
+data:
+  METADATA_STORAGE_PASSWORD: <PASSWORD>
+---
+spec:
+  envFrom:
+    - secretRef:
+        name: metadata-storage-password
+  nodes:
+    master:
+      runtime.properties: |
+        # General
+        druid.service=druid/coordinator
+
+        # Metadata Storage
+        druid.metadata.storage.type=<TYPE>
+        druid.metadata.storage.connector.connectURI=<URI>
+        druid.metadata.storage.connector.user=<USERNAME>
+        druid.metadata.storage.connector.password={ "type": "environment", "variable": "METADATA_STORAGE_PASSWORD" }
+```

--- a/docs/features.md
+++ b/docs/features.md
@@ -44,7 +44,7 @@
 - ```NOTE: User must be aware of this feature, there might be cases where crashloopback might be caused due probe failure, fault image etc, the operator shall keep on deleting on each re-concile loop. Default Behavior is True ```
 
 ## Scaling of Druid Nodes
-- Operator supports ```HPA autosaling/v2beta2``` Spec in the nodeSpec for druid nodes. In case HPA deployed, HPA controller maintains the replica count/state for the particular statefulset referenced.  Refer to ```examples.md``` for HPA configuration. 
+- Operator supports ```HPA autosaling/v2``` Spec in the nodeSpec for druid nodes. In case HPA deployed, HPA controller maintains the replica count/state for the particular statefulset referenced.  Refer to ```examples.md``` for HPA configuration. 
 - ```NOTE: Prefered to scale only brokers using HPA.```
 - In order to scale MM with HPA, its recommended not to use HPA. Refer to these discussions which have adderessed the issues in details.
 1. https://github.com/apache/druid/issues/8801#issuecomment-664020630


### PR DESCRIPTION
Fixes #74 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

In addition to the operator's example usage. This example includes how to configure the metadata storage's password in a secure way.

Also fixing the API version of the supported hpa in another doc.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `examples.md`
 * `features.md`
