### PR TITLE
install hadoop dependencies on init example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -304,3 +304,34 @@
         - -instance=instance
         - -logFiles=logFiles
 ```
+
+## Install hadoop-dependencies With Init Container
+
+```yaml
+spec:
+  volumeMounts:
+    - mountPath: /opt/druid/hadoop-dependencies
+      name: hadoop-dependencies
+  volumes:
+    - emptyDir:
+        sizeLimit: 500Mi
+      name: hadoop-dependencies
+  additionalContainer:
+    - command:
+        - java
+        - -cp
+        - lib/*
+        - -Ddruid.extensions.hadoopDependenciesDir=/hadoop-dependencies
+        - org.apache.druid.cli.Main
+        - tools
+        - pull-deps
+        - -h
+        - org.apache.hadoop:hadoop-client:3.3.0
+        - --no-default-hadoop
+      containerName: hadoop-dependencies
+      image: apache/druid:25.0.0
+      runAsInit: true
+      volumeMounts:
+        - mountPath: /hadoop-dependencies
+          name: hadoop-dependencies
+```


### PR DESCRIPTION
### Description

An addition to the operator's example usage. This example includes how to create an init container that will load hadoop-dependencies into each pod.
<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
