### PR TITLE
refactor(api): changing rollingUpdate default to true

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -224,8 +224,9 @@ type DruidSpec struct {
 	// If set to true then operator checks the rollout status of previous version StateSets before updating next.
 	// Used only for updates.
 
-	// +optional
-	RollingDeploy bool `json:"rollingDeploy,omitempty"`
+	// +required
+	// +kubebuilder:default:=true
+	RollingDeploy bool `json:"rollingDeploy"`
 
 	// futuristic stuff to make Druid dependency setup extensible from within Druid operator
 	// ignore for now.

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -8652,6 +8652,7 @@ spec:
                     type: integer
                 type: object
               rollingDeploy:
+                default: true
                 type: boolean
               scalePvcSts:
                 description: ScalePvcSts, defaults to false. When enabled, operator
@@ -11560,6 +11561,7 @@ spec:
             - common.runtime.properties
             - commonConfigMountPath
             - nodes
+            - rollingDeploy
             - startScript
             type: object
           status:

--- a/config/crd/bases/druid.apache.org_druids.yaml
+++ b/config/crd/bases/druid.apache.org_druids.yaml
@@ -8652,6 +8652,7 @@ spec:
                     type: integer
                 type: object
               rollingDeploy:
+                default: true
                 type: boolean
               scalePvcSts:
                 description: ScalePvcSts, defaults to false. When enabled, operator
@@ -11560,6 +11561,7 @@ spec:
             - common.runtime.properties
             - commonConfigMountPath
             - nodes
+            - rollingDeploy
             - startScript
             type: object
           status:


### PR DESCRIPTION
Fixes #81 

### Description

Druid requires a [rolling update](https://druid.apache.org/docs/latest/operations/rolling-updates.html) in order to apply changes with no downtime. The operator supports it with the `rollingUpdate` field.  
Currently, this behavior is disabled by default for no reason.
This PR changes Druid's API `rollingUpdate` field to be `true` by default. This is done by using a Kubebuilder marker.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `apis/druid/v1alpha1/druid_types.go`
