### PR TITLE
fix(nil pointer): storage class reference

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1447,8 +1447,11 @@ func verifyDruidSpec(drd *v1alpha1.Druid) error {
 		return err
 	}
 
-	errorMsg := ""
+	if err = validateVolumeClaimTemplateSpec(drd); err != nil {
+		return err
+	}
 
+	errorMsg := ""
 	for key, node := range drd.Spec.Nodes {
 		if drd.Spec.Image == "" && node.Image == "" {
 			errorMsg = fmt.Sprintf("%sImage missing from Druid Cluster Spec\n", errorMsg)

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -14,7 +14,6 @@ import (
 
 	autoscalev2 "k8s.io/api/autoscaling/v2"
 	networkingv1 "k8s.io/api/networking/v1"
-	storage "k8s.io/api/storage/v1"
 
 	"github.com/datainfrahq/druid-operator/apis/druid/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -189,11 +188,8 @@ func deployDruidCluster(ctx context.Context, sdk client.Client, m *v1alpha1.Drui
 			//  Ignore for the first iteration ie cluster creation, else get sts shall unnecessary log errors.
 
 			if m.Generation > 1 && m.Spec.ScalePvcSts {
-				if isVolumeExpansionEnabled(ctx, sdk, m, &nodeSpec, emitEvents) {
-					err := scalePVCForSts(ctx, sdk, &nodeSpec, nodeSpecUniqueStr, m, emitEvents)
-					if err != nil {
-						return err
-					}
+				if err := expandStatefulSetVolumes(ctx, sdk, m, &nodeSpec, emitEvents, nodeSpecUniqueStr); err != nil {
+					return err
 				}
 			}
 
@@ -818,116 +814,6 @@ func isObjFullyDeployed(ctx context.Context, sdk client.Client, nodeSpec v1alpha
 	return false, nil
 }
 
-// scalePVCForSts shall expand the sts volumeclaimtemplates size as well as N no of pvc supported by the sts.
-// NOTE: To be called only if generation > 1
-func scalePVCForSts(ctx context.Context, sdk client.Client, nodeSpec *v1alpha1.DruidNodeSpec, nodeSpecUniqueStr string, drd *v1alpha1.Druid, emitEvent EventEmitter) error {
-
-	getSTSList, err := readers.List(ctx, sdk, drd, makeLabelsForDruid(drd.Name), emitEvent, func() objectList { return &appsv1.StatefulSetList{} }, func(listObj runtime.Object) []object {
-		items := listObj.(*appsv1.StatefulSetList).Items
-		result := make([]object, len(items))
-		for i := 0; i < len(items); i++ {
-			result[i] = &items[i]
-		}
-		return result
-	})
-	if err != nil {
-		return nil
-	}
-
-	// Dont proceed unless all statefulsets are up and running.
-	//  This can cause the go routine to panic
-
-	for _, sts := range getSTSList {
-		if sts.(*appsv1.StatefulSet).Status.Replicas != sts.(*appsv1.StatefulSet).Status.ReadyReplicas {
-			return nil
-		}
-	}
-
-	// return nil, in case return err the program halts since sts would not be able
-	// we would like the operator to create sts.
-	sts, err := readers.Get(ctx, sdk, nodeSpecUniqueStr, drd, func() object { return &appsv1.StatefulSet{} }, emitEvent)
-	if err != nil {
-		return nil
-	}
-
-	pvcLabels := map[string]string{
-		"component": nodeSpec.NodeType,
-	}
-
-	pvcList, err := readers.List(ctx, sdk, drd, pvcLabels, emitEvent, func() objectList { return &v1.PersistentVolumeClaimList{} }, func(listObj runtime.Object) []object {
-		items := listObj.(*v1.PersistentVolumeClaimList).Items
-		result := make([]object, len(items))
-		for i := 0; i < len(items); i++ {
-			result[i] = &items[i]
-		}
-		return result
-	})
-	if err != nil {
-		return nil
-	}
-
-	desVolumeClaimTemplateSize, currVolumeClaimTemplateSize, pvcSize := getVolumeClaimTemplateSizes(sts, nodeSpec, pvcList)
-
-	// current number of PVC can't be less than desired number of pvc
-	if len(pvcSize) < len(desVolumeClaimTemplateSize) {
-		return nil
-	}
-
-	// iterate over array for matching each index in desVolumeClaimTemplateSize, currVolumeClaimTemplateSize and pvcSize
-	for i := range desVolumeClaimTemplateSize {
-
-		// Validate Request, shrinking of pvc not supported
-		// desired size cant be less than current size
-		// in that case re-create sts/pvc which is a user execute manual step
-
-		desiredSize, _ := desVolumeClaimTemplateSize[i].AsInt64()
-		currentSize, _ := currVolumeClaimTemplateSize[i].AsInt64()
-
-		if desiredSize < currentSize {
-			e := fmt.Errorf("Request for Shrinking of sts pvc size [sts:%s] in [namespace:%s] is not Supported", sts.(*appsv1.StatefulSet).Name, sts.(*appsv1.StatefulSet).Namespace)
-			logger.Error(e, e.Error(), "name", drd.Name, "namespace", drd.Namespace)
-			emitEvent.EmitEventGeneric(drd, "DruidOperatorPvcReSizeFail", "", err)
-			return e
-		}
-
-		// In case size dont match and dessize > currsize, delete the sts using casacde=false / propagation policy set to orphan
-		// The operator on next reconcile shall create the sts with latest changes
-		if desiredSize != currentSize {
-			msg := fmt.Sprintf("Detected Change in VolumeClaimTemplate Sizes for Statefuleset [%s] in Namespace [%s], desVolumeClaimTemplateSize: [%s], currVolumeClaimTemplateSize: [%s]\n, deleteing STS [%s] with casacde=false]", sts.(*appsv1.StatefulSet).Name, sts.(*appsv1.StatefulSet).Namespace, desVolumeClaimTemplateSize[i].String(), currVolumeClaimTemplateSize[i].String(), sts.(*appsv1.StatefulSet).Name)
-			logger.Info(msg)
-			emitEvent.EmitEventGeneric(drd, "DruidOperatorPvcReSizeDetected", msg, nil)
-
-			if err := writers.Delete(ctx, sdk, drd, sts, emitEvent, client.PropagationPolicy(metav1.DeletePropagationOrphan)); err != nil {
-				return err
-			} else {
-				msg := fmt.Sprintf("[StatefuleSet:%s] successfully deleted with casacde=false", sts.(*appsv1.StatefulSet).Name)
-				logger.Info(msg, "name", drd.Name, "namespace", drd.Namespace)
-				emitEvent.EmitEventGeneric(drd, "DruidOperatorStsOrphaned", msg, nil)
-			}
-
-		}
-
-		// In case size dont match, patch the pvc with the desiredsize from druid CR
-		for p := range pvcSize {
-			pSize, _ := pvcSize[p].AsInt64()
-			if desiredSize != pSize {
-				// use deepcopy
-				patch := client.MergeFrom(pvcList[p].(*v1.PersistentVolumeClaim).DeepCopy())
-				pvcList[p].(*v1.PersistentVolumeClaim).Spec.Resources.Requests[v1.ResourceStorage] = desVolumeClaimTemplateSize[i]
-				if err := writers.Patch(ctx, sdk, drd, pvcList[p].(*v1.PersistentVolumeClaim), false, patch, emitEvent); err != nil {
-					return err
-				} else {
-					msg := fmt.Sprintf("[PVC:%s] successfully Patched with [Size:%s]", pvcList[p].(*v1.PersistentVolumeClaim).Name, desVolumeClaimTemplateSize[i].String())
-					logger.Info(msg, "name", drd.Name, "namespace", drd.Namespace)
-				}
-			}
-		}
-
-	}
-
-	return nil
-}
-
 // desVolumeClaimTemplateSize: the druid CR holds this value for a sts volumeclaimtemplate
 // currVolumeClaimTemplateSize: the sts owned by druid CR holds this value in volumeclaimtemplate
 // pvcSize: the pvc referenced by the sts holds this value
@@ -948,21 +834,6 @@ func getVolumeClaimTemplateSizes(sts object, nodeSpec *v1alpha1.DruidNodeSpec, p
 
 	return desVolumeClaimTemplateSize, currVolumeClaimTemplateSize, pvcSize
 
-}
-
-func isVolumeExpansionEnabled(ctx context.Context, sdk client.Client, m *v1alpha1.Druid, nodeSpec *v1alpha1.DruidNodeSpec, emitEvent EventEmitter) bool {
-
-	for _, nodeVCT := range nodeSpec.VolumeClaimTemplates {
-		sc, err := readers.Get(ctx, sdk, *nodeVCT.Spec.StorageClassName, m, func() object { return &storage.StorageClass{} }, emitEvent)
-		if err != nil {
-			return false
-		}
-
-		if sc.(*storage.StorageClass).AllowVolumeExpansion != boolFalse() {
-			return true
-		}
-	}
-	return false
 }
 
 func stringifyForLogging(obj object, drd *v1alpha1.Druid) string {

--- a/controllers/druid/testdata/volume-expansion.yaml
+++ b/controllers/druid/testdata/volume-expansion.yaml
@@ -1,0 +1,84 @@
+apiVersion: druid.apache.org/v1alpha1
+kind: Druid
+metadata:
+  name: volume-expansion
+  namespace: default
+spec:
+  image: apache/druid:25.0.0
+  startScript: /druid.sh
+  rollingDeploy: false
+  securityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+    runAsGroup: 1000
+  services:
+    - spec:
+        type: ClusterIP
+  commonConfigMountPath: "/opt/druid/conf/druid/cluster/_common"
+  jvm.options: |-
+    -server
+    -XX:MaxDirectMemorySize=10240g
+    -Duser.timezone=UTC
+    -Dfile.encoding=UTF-8
+    -Djava.io.tmpdir=/druid/data
+  common.runtime.properties: |-
+    # Metadata Store
+    druid.metadata.storage.type=derby
+    druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
+    druid.metadata.storage.connector.host=localhost
+    druid.metadata.storage.connector.port=1527
+    druid.metadata.storage.connector.createTables=true
+    
+    # Deep Storage
+    druid.storage.type=local
+    druid.storage.storageDirectory=/druid/deepstorage
+    
+    # Service discovery
+    druid.selectors.indexing.serviceName=druid/overlord
+    druid.selectors.coordinator.serviceName=druid/coordinator
+  nodes:
+    brokers:
+      nodeType: "broker"
+      kind: "Deployment"
+      druid.port: 8088
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/broker"
+      replicas: 1
+      runtime.properties: |-
+        druid.service=druid/broker
+      additionalContainer:
+        - command:
+            - /bin/sh echo hello
+          containerName: node-level
+          image: hello-world
+    coordinators:
+      nodeType: "coordinator"
+      druid.port: 8080
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/master/coordinator-overlord"
+      replicas: 1
+      runtime.properties: |-
+        druid.service=druid/coordinator
+        druid.coordinator.asOverlord.enabled=true
+        druid.coordinator.asOverlord.overlordService=druid/overlord
+    historicals:
+      nodeType: "historical"
+      kind: "StatefulSet"
+      druid.port: 8080
+      nodeConfigMountPath: "/opt/druid/conf/druid/cluster/data/historical"
+      replicas: 1
+      runtime.properties: |-
+        druid.service=druid/historical
+        druid.segmentCache.locations=[{\"path\":\"/druid/data/segments\",\"maxSize\":10737418240}]
+        druid.server.maxSize=10737418240
+      volumeMounts:
+        - mountPath: /druid/data
+          name: data-volume
+      volumeClaimTemplates:
+        - metadata:
+            name: data-volume
+          spec:
+            storageClassName: default
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 10M

--- a/controllers/druid/volume_expansion.go
+++ b/controllers/druid/volume_expansion.go
@@ -1,0 +1,163 @@
+package druid
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/datainfrahq/druid-operator/apis/druid/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func expandStatefulSetVolumes(ctx context.Context, sdk client.Client, m *v1alpha1.Druid,
+	nodeSpec *v1alpha1.DruidNodeSpec, emitEvent EventEmitter, nodeSpecUniqueStr string) error {
+
+	isEnabled, err := isVolumeExpansionEnabled(ctx, sdk, m, nodeSpec, emitEvent)
+	if err != nil {
+		return err
+	}
+
+	if isEnabled {
+		err := scalePVCForSts(ctx, sdk, nodeSpec, nodeSpecUniqueStr, m, emitEvent)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isVolumeExpansionEnabled(ctx context.Context, sdk client.Client, m *v1alpha1.Druid, nodeSpec *v1alpha1.DruidNodeSpec, emitEvent EventEmitter) (bool, error) {
+
+	for _, nodeVCT := range nodeSpec.VolumeClaimTemplates {
+		if nodeVCT.Spec.StorageClassName == nil {
+			err := errors.New("StorageClassName does not exists")
+			logger.WithValues("NodeType", nodeSpec.NodeType, "VolumeClaimTemplate", nodeVCT.Name).
+				Error(err, "storageClassName does not exists in spec")
+			return false, err
+		}
+		sc, err := readers.Get(ctx, sdk, *nodeVCT.Spec.StorageClassName, m, func() object { return &storage.StorageClass{} }, emitEvent)
+		if err != nil {
+			return false, err
+		}
+
+		if sc.(*storage.StorageClass).AllowVolumeExpansion != boolFalse() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// scalePVCForSts shall expand the StatefulSet's VolumeClaimTemplates size as well as N no of pvc supported by the sts.
+func scalePVCForSts(ctx context.Context, sdk client.Client, nodeSpec *v1alpha1.DruidNodeSpec, nodeSpecUniqueStr string, drd *v1alpha1.Druid, emitEvent EventEmitter) error {
+
+	getSTSList, err := readers.List(ctx, sdk, drd, makeLabelsForDruid(drd.Name), emitEvent, func() objectList { return &appsv1.StatefulSetList{} }, func(listObj runtime.Object) []object {
+		items := listObj.(*appsv1.StatefulSetList).Items
+		result := make([]object, len(items))
+		for i := 0; i < len(items); i++ {
+			result[i] = &items[i]
+		}
+		return result
+	})
+	if err != nil {
+		return nil
+	}
+
+	// Dont proceed unless all statefulsets are up and running.
+	//  This can cause the go routine to panic
+
+	for _, sts := range getSTSList {
+		if sts.(*appsv1.StatefulSet).Status.Replicas != sts.(*appsv1.StatefulSet).Status.ReadyReplicas {
+			return nil
+		}
+	}
+
+	// return nil, in case return err the program halts since sts would not be able
+	// we would like the operator to create sts.
+	sts, err := readers.Get(ctx, sdk, nodeSpecUniqueStr, drd, func() object { return &appsv1.StatefulSet{} }, emitEvent)
+	if err != nil {
+		return nil
+	}
+
+	pvcLabels := map[string]string{
+		"component": nodeSpec.NodeType,
+	}
+
+	pvcList, err := readers.List(ctx, sdk, drd, pvcLabels, emitEvent, func() objectList { return &v1.PersistentVolumeClaimList{} }, func(listObj runtime.Object) []object {
+		items := listObj.(*v1.PersistentVolumeClaimList).Items
+		result := make([]object, len(items))
+		for i := 0; i < len(items); i++ {
+			result[i] = &items[i]
+		}
+		return result
+	})
+	if err != nil {
+		return nil
+	}
+
+	desVolumeClaimTemplateSize, currVolumeClaimTemplateSize, pvcSize := getVolumeClaimTemplateSizes(sts, nodeSpec, pvcList)
+
+	// current number of PVC can't be less than desired number of pvc
+	if len(pvcSize) < len(desVolumeClaimTemplateSize) {
+		return nil
+	}
+
+	// iterate over array for matching each index in desVolumeClaimTemplateSize, currVolumeClaimTemplateSize and pvcSize
+	for i := range desVolumeClaimTemplateSize {
+
+		// Validate Request, shrinking of pvc not supported
+		// desired size cant be less than current size
+		// in that case re-create sts/pvc which is a user execute manual step
+
+		desiredSize, _ := desVolumeClaimTemplateSize[i].AsInt64()
+		currentSize, _ := currVolumeClaimTemplateSize[i].AsInt64()
+
+		if desiredSize < currentSize {
+			e := fmt.Errorf("Request for Shrinking of sts pvc size [sts:%s] in [namespace:%s] is not Supported", sts.(*appsv1.StatefulSet).Name, sts.(*appsv1.StatefulSet).Namespace)
+			logger.Error(e, e.Error(), "name", drd.Name, "namespace", drd.Namespace)
+			emitEvent.EmitEventGeneric(drd, "DruidOperatorPvcReSizeFail", "", err)
+			return e
+		}
+
+		// In case size dont match and dessize > currsize, delete the sts using casacde=false / propagation policy set to orphan
+		// The operator on next reconcile shall create the sts with latest changes
+		if desiredSize != currentSize {
+			msg := fmt.Sprintf("Detected Change in VolumeClaimTemplate Sizes for Statefuleset [%s] in Namespace [%s], desVolumeClaimTemplateSize: [%s], currVolumeClaimTemplateSize: [%s]\n, deleteing STS [%s] with casacde=false]", sts.(*appsv1.StatefulSet).Name, sts.(*appsv1.StatefulSet).Namespace, desVolumeClaimTemplateSize[i].String(), currVolumeClaimTemplateSize[i].String(), sts.(*appsv1.StatefulSet).Name)
+			logger.Info(msg)
+			emitEvent.EmitEventGeneric(drd, "DruidOperatorPvcReSizeDetected", msg, nil)
+
+			if err := writers.Delete(ctx, sdk, drd, sts, emitEvent, client.PropagationPolicy(metav1.DeletePropagationOrphan)); err != nil {
+				return err
+			} else {
+				msg := fmt.Sprintf("[StatefuleSet:%s] successfully deleted with casacde=false", sts.(*appsv1.StatefulSet).Name)
+				logger.Info(msg, "name", drd.Name, "namespace", drd.Namespace)
+				emitEvent.EmitEventGeneric(drd, "DruidOperatorStsOrphaned", msg, nil)
+			}
+
+		}
+
+		// In case size dont match, patch the pvc with the desiredsize from druid CR
+		for p := range pvcSize {
+			pSize, _ := pvcSize[p].AsInt64()
+			if desiredSize != pSize {
+				// use deepcopy
+				patch := client.MergeFrom(pvcList[p].(*v1.PersistentVolumeClaim).DeepCopy())
+				pvcList[p].(*v1.PersistentVolumeClaim).Spec.Resources.Requests[v1.ResourceStorage] = desVolumeClaimTemplateSize[i]
+				if err := writers.Patch(ctx, sdk, drd, pvcList[p].(*v1.PersistentVolumeClaim), false, patch, emitEvent); err != nil {
+					return err
+				} else {
+					msg := fmt.Sprintf("[PVC:%s] successfully Patched with [Size:%s]", pvcList[p].(*v1.PersistentVolumeClaim).Name, desVolumeClaimTemplateSize[i].String())
+					logger.Info(msg, "name", drd.Name, "namespace", drd.Namespace)
+				}
+			}
+		}
+
+	}
+
+	return nil
+}

--- a/controllers/druid/volume_expansion_test.go
+++ b/controllers/druid/volume_expansion_test.go
@@ -1,0 +1,61 @@
+package druid
+
+import (
+	"time"
+
+	druidv1alpha1 "github.com/datainfrahq/druid-operator/apis/druid/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+/*
+zookeeper_dep_mgmt_test
+*/
+var _ = Describe("Test volume expansion feature", func() {
+	const (
+		filePath = "testdata/volume-expansion.yaml"
+		timeout  = time.Second * 45
+		interval = time.Millisecond * 250
+	)
+
+	Context("When checking if volume expansion is enabled", func() {
+		It("should error if storageClassName does not exists", func() {
+			druid := &druidv1alpha1.Druid{}
+
+			druidCR, err := readDruidClusterSpecFromFile(filePath)
+			Expect(err).Should(BeNil())
+
+			By("By setting storage class name to nil")
+			druidCR.Spec.Nodes["historicals"].VolumeClaimTemplates[0].Spec.StorageClassName = nil
+
+			Expect(druidCR.Spec.Nodes["historicals"].VolumeClaimTemplates[0].Spec.StorageClassName).Should(BeNil())
+
+			By("By creating a new druidCR")
+			Expect(k8sClient.Create(ctx, druidCR)).To(Succeed())
+
+			By("By getting a newly created druidCR")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: druidCR.Name, Namespace: druidCR.Namespace}, druid)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("By getting the historicals nodeSpec")
+			allNodeSpecs, err := getAllNodeSpecsInDruidPrescribedOrder(druid)
+			Expect(err).Should(BeNil())
+
+			nodeSpec := &druidv1alpha1.DruidNodeSpec{}
+			for _, elem := range allNodeSpecs {
+				if elem.key == "historicals" {
+					nodeSpec = &elem.spec
+				}
+			}
+			Expect(nodeSpec).ShouldNot(BeNil())
+
+			By("By calling the expand volume function with storageClass nil")
+			Expect(isVolumeExpansionEnabled(ctx, k8sClient, druid, nodeSpec, nil)).Error()
+		})
+	})
+})


### PR DESCRIPTION
Fixes #1 

### Description

This PR fixes the issue where the operator gets a nil pointer exception while trying to reach the storage class name of a storage class name template when it is not specified.

Important:  
`StorageClassName` is generally not a required field (https://github.com/kubernetes/kubernetes/blob/0cabb55f7c05eb269ae6f7292271833f095657ec/pkg/apis/core/types.go#L461).  
If a storage class is not provided, Kubernetes checks the default StorageClass (https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass).  
This is tricky because there could be multiple storage classes and very dangerous to Druid (https://github.com/kubernetes/kubernetes/blob/0cabb55f7c05eb269ae6f7292271833f095657ec/test/e2e/framework/pv/pv.go#L822).  
Therefore, we will require users to specify a storage class when they add a volume claim template to their StatefulSets.

Backward compatibility:
Not specifying `storageClassName` is a very unpopular behavior but it may happen. Such users will have to check their `Druid` workloads and add a storage class to their claim templates 

This PR adds a feature of validation of storage class names inside a Node of kind StatefulSet. It also adds a nil check before trying to reach this field.

Tests are also added to check both logics.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `handler.go`
 * `volume_expansion.go`
 * `volume_expansion_test.go`
