### PR TITLE
Allow configuration of kubebuilder/kube-rbac-proxy image

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -48,7 +48,8 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          image: "{{ .Values.kube_rbac_proxy.image.repository }}:{{ .Values.kube_rbac_proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.kube_rbac_proxy.image.pullPolicy }}
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,6 +16,13 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+kube_rbac_proxy:
+  image:
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: "v0.13.1"
+
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
### Description

Allow the configuration of the Containerimage Repository of the kubebuilder/kube-rbac-proxy in case of usage in private kubernetes clusters

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `chart/Chart.yaml`
 * `chart/templates/deployment.yaml`
 * `chart/values.yaml`
