### PR TITLE
fix: readiness probe on historical

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -241,6 +241,12 @@ type DruidSpec struct {
 	// +kubebuilder:default:=true
 	RollingDeploy bool `json:"rollingDeploy"`
 
+	// DefaultProbes If set to true this will add default probes (liveness / readiness / startup) for all druid components
+	// but it won't override existing probes
+	// +optional
+	// +kubebuilder:default:=true
+	DefaultProbes bool `json:"defaultProbes"`
+
 	// Zookeeper IGNORED (Future API): In order to make Druid dependency setup extensible from within Druid operator.
 	// +optional
 	Zookeeper *ZookeeperSpec `json:"zookeeper,omitempty"`

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -18,7 +18,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Druid is the Schema for the druids API
+        description: Druid is the Schema for the druids API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -49,7 +49,7 @@ spec:
                         type: string
                       type: array
                     command:
-                      description: Command
+                      description: Command command for the additional container.
                       items:
                         type: string
                       type: array
@@ -215,15 +215,14 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: Image
+                      description: Image Image of the additional container.
                       type: string
                     imagePullPolicy:
                       description: ImagePullPolicy If not present, will be taken from
-                        top level spec
+                        top level spec.
                       type: string
                     resources:
-                      description: Resources Kubernetes Native resource requirements
-                        specification.
+                      description: Resources Kubernetes Native `resources` specification.
                       properties:
                         claims:
                           description: "Claims lists the names of resources, defined
@@ -450,7 +449,7 @@ spec:
                           type: object
                       type: object
                     volumeMounts:
-                      description: VolumeMounts Kubernetes Native volume mounts specification.
+                      description: VolumeMounts Kubernetes Native `VolumeMount` specification.
                       items:
                         description: VolumeMount describes a mounting of a Volume
                           within a container.
@@ -1510,6 +1509,12 @@ spec:
                 - spec
                 - type
                 type: object
+              defaultProbes:
+                default: true
+                description: DefaultProbes If set to true this will add default probes
+                  (liveness / readiness / startup) for all druid components but it
+                  won't override existing probes
+                type: boolean
               deleteOrphanPvc:
                 default: true
                 description: DeleteOrphanPvc Orphaned (unmounted PVCs) shall be cleaned
@@ -1748,6 +1753,7 @@ spec:
                 description: Image Required here or at the NodeSpec level.
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy
                 type: string
               imagePullSecrets:
@@ -1930,8 +1936,9 @@ spec:
                 - type
                 type: object
               metricDimensions.json:
-                description: DimensionsMapPath Custom Dimension Map Path for statsd
-                  emitter.
+                description: 'DimensionsMapPath Custom Dimension Map Path for statsd
+                  emitter. stastd documentation is described in the following documentation:
+                  https://druid.apache.org/docs/latest/development/extensions-contrib/statsd.html'
                 type: string
               nodeSelector:
                 additionalProperties:
@@ -1951,26 +1958,26 @@ spec:
                       description: Operator deploys the sidecar container based on
                         these properties.
                       items:
-                        description: AdditionalContainer defines the additional sidecar
-                          container
+                        description: 'AdditionalContainer defines additional sidecar
+                          containers to be deployed with the `Druid` pods. (will be
+                          part of Kubernetes native in the future: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/753-sidecar-containers/README.md#summary).'
                         properties:
                           args:
-                            description: Argument to call the command
+                            description: Args Arguments to call the command.
                             items:
                               type: string
                             type: array
                           command:
-                            description: This is the command for the additional container
-                              to run.
+                            description: Command command for the additional container.
                             items:
                               type: string
                             type: array
                           containerName:
-                            description: This is the name of the additional container.
+                            description: ContainerName name of the additional container.
                             type: string
                           env:
-                            description: Environment variables for the Additional
-                              Container
+                            description: Env Environment variables for the additional
+                              container.
                             items:
                               description: EnvVar represents an environment variable
                                 present in a Container.
@@ -2090,7 +2097,8 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: Extra environment variables
+                            description: EnvFrom Extra environment variables from
+                              remote source (ConfigMaps, Secrets...).
                             items:
                               description: EnvFromSource represents the source of
                                 a set of ConfigMaps
@@ -2132,15 +2140,14 @@ spec:
                               type: object
                             type: array
                           image:
-                            description: This is the image for the additional container
-                              to run.
+                            description: Image Image of the additional container.
                             type: string
                           imagePullPolicy:
-                            description: If not present, will be taken from top level
-                              spec
+                            description: ImagePullPolicy If not present, will be taken
+                              from top level spec.
                             type: string
                           resources:
-                            description: CPU/Memory Resources
+                            description: Resources Kubernetes Native `resources` specification.
                             properties:
                               claims:
                                 description: "Claims lists the names of resources,
@@ -2191,10 +2198,12 @@ spec:
                                 type: object
                             type: object
                           runAsInit:
+                            description: RunAsInit indicate whether this should be
+                              an init container.
                             type: boolean
                           securityContext:
-                            description: ContainerSecurityContext. If not present,
-                              will be taken from top level pod
+                            description: ContainerSecurityContext If not present,
+                              will be taken from top level pod.
                             properties:
                               allowPrivilegeEscalation:
                                 description: 'AllowPrivilegeEscalation controls whether
@@ -2373,7 +2382,8 @@ spec:
                                 type: object
                             type: object
                           volumeMounts:
-                            description: Volumes etc for the Druid pods
+                            description: VolumeMounts Kubernetes Native `VolumeMount`
+                              specification.
                             items:
                               description: VolumeMount describes a mounting of a Volume
                                 within a container.
@@ -5499,7 +5509,8 @@ spec:
                         workload's pods.
                       type: object
                     podManagementPolicy:
-                      description: PodManagementPolicy By default, it is set to "parallel"
+                      default: Parallel
+                      description: PodManagementPolicy
                       type: string
                     ports:
                       description: Ports Extra ports to be added to pod spec.
@@ -5693,8 +5704,7 @@ spec:
                       minimum: 0
                       type: integer
                     resources:
-                      description: Resources Kubernetes Native resource requirements
-                        specification.
+                      description: Resources Kubernetes Native `resources` specification.
                       properties:
                         claims:
                           description: "Claims lists the names of resources, defined
@@ -9019,6 +9029,7 @@ spec:
                 description: PodLabels Custom labels to be populated in `Druid` pods.
                 type: object
               podManagementPolicy:
+                default: Parallel
                 description: PodManagementPolicy
                 type: string
               readinessProbe:
@@ -10028,7 +10039,7 @@ spec:
                     type: integer
                 type: object
               tolerations:
-                description: Tolerations Kubernetes native `toleration` specification.
+                description: Tolerations Kubernetes native `tolerations` specification.
                 items:
                   description: The pod this Toleration is attached to tolerates any
                     taint that matches the triple <key,value,effect> using the matching
@@ -10486,7 +10497,7 @@ spec:
                   type: object
                 type: array
               volumes:
-                description: Volumes Kubernetes Native `Volume` specification.
+                description: Volumes Kubernetes Native `Volumes` specification.
                 items:
                   description: Volume represents a named volume in a pod that may
                     be accessed by any container in the pod.

--- a/config/crd/bases/druid.apache.org_druids.yaml
+++ b/config/crd/bases/druid.apache.org_druids.yaml
@@ -18,7 +18,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Druid is the Schema for the druids API
+        description: Druid is the Schema for the druids API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -49,7 +49,7 @@ spec:
                         type: string
                       type: array
                     command:
-                      description: Command
+                      description: Command command for the additional container.
                       items:
                         type: string
                       type: array
@@ -215,15 +215,14 @@ spec:
                         type: object
                       type: array
                     image:
-                      description: Image
+                      description: Image Image of the additional container.
                       type: string
                     imagePullPolicy:
                       description: ImagePullPolicy If not present, will be taken from
-                        top level spec
+                        top level spec.
                       type: string
                     resources:
-                      description: Resources Kubernetes Native resource requirements
-                        specification.
+                      description: Resources Kubernetes Native `resources` specification.
                       properties:
                         claims:
                           description: "Claims lists the names of resources, defined
@@ -450,7 +449,7 @@ spec:
                           type: object
                       type: object
                     volumeMounts:
-                      description: VolumeMounts Kubernetes Native volume mounts specification.
+                      description: VolumeMounts Kubernetes Native `VolumeMount` specification.
                       items:
                         description: VolumeMount describes a mounting of a Volume
                           within a container.
@@ -1510,6 +1509,12 @@ spec:
                 - spec
                 - type
                 type: object
+              defaultProbes:
+                default: true
+                description: DefaultProbes If set to true this will add default probes
+                  (liveness / readiness / startup) for all druid components but it
+                  won't override existing probes
+                type: boolean
               deleteOrphanPvc:
                 default: true
                 description: DeleteOrphanPvc Orphaned (unmounted PVCs) shall be cleaned
@@ -1748,6 +1753,7 @@ spec:
                 description: Image Required here or at the NodeSpec level.
                 type: string
               imagePullPolicy:
+                default: IfNotPresent
                 description: ImagePullPolicy
                 type: string
               imagePullSecrets:
@@ -1930,8 +1936,9 @@ spec:
                 - type
                 type: object
               metricDimensions.json:
-                description: DimensionsMapPath Custom Dimension Map Path for statsd
-                  emitter.
+                description: 'DimensionsMapPath Custom Dimension Map Path for statsd
+                  emitter. stastd documentation is described in the following documentation:
+                  https://druid.apache.org/docs/latest/development/extensions-contrib/statsd.html'
                 type: string
               nodeSelector:
                 additionalProperties:
@@ -1951,26 +1958,26 @@ spec:
                       description: Operator deploys the sidecar container based on
                         these properties.
                       items:
-                        description: AdditionalContainer defines the additional sidecar
-                          container
+                        description: 'AdditionalContainer defines additional sidecar
+                          containers to be deployed with the `Druid` pods. (will be
+                          part of Kubernetes native in the future: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/753-sidecar-containers/README.md#summary).'
                         properties:
                           args:
-                            description: Argument to call the command
+                            description: Args Arguments to call the command.
                             items:
                               type: string
                             type: array
                           command:
-                            description: This is the command for the additional container
-                              to run.
+                            description: Command command for the additional container.
                             items:
                               type: string
                             type: array
                           containerName:
-                            description: This is the name of the additional container.
+                            description: ContainerName name of the additional container.
                             type: string
                           env:
-                            description: Environment variables for the Additional
-                              Container
+                            description: Env Environment variables for the additional
+                              container.
                             items:
                               description: EnvVar represents an environment variable
                                 present in a Container.
@@ -2090,7 +2097,8 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: Extra environment variables
+                            description: EnvFrom Extra environment variables from
+                              remote source (ConfigMaps, Secrets...).
                             items:
                               description: EnvFromSource represents the source of
                                 a set of ConfigMaps
@@ -2132,15 +2140,14 @@ spec:
                               type: object
                             type: array
                           image:
-                            description: This is the image for the additional container
-                              to run.
+                            description: Image Image of the additional container.
                             type: string
                           imagePullPolicy:
-                            description: If not present, will be taken from top level
-                              spec
+                            description: ImagePullPolicy If not present, will be taken
+                              from top level spec.
                             type: string
                           resources:
-                            description: CPU/Memory Resources
+                            description: Resources Kubernetes Native `resources` specification.
                             properties:
                               claims:
                                 description: "Claims lists the names of resources,
@@ -2191,10 +2198,12 @@ spec:
                                 type: object
                             type: object
                           runAsInit:
+                            description: RunAsInit indicate whether this should be
+                              an init container.
                             type: boolean
                           securityContext:
-                            description: ContainerSecurityContext. If not present,
-                              will be taken from top level pod
+                            description: ContainerSecurityContext If not present,
+                              will be taken from top level pod.
                             properties:
                               allowPrivilegeEscalation:
                                 description: 'AllowPrivilegeEscalation controls whether
@@ -2373,7 +2382,8 @@ spec:
                                 type: object
                             type: object
                           volumeMounts:
-                            description: Volumes etc for the Druid pods
+                            description: VolumeMounts Kubernetes Native `VolumeMount`
+                              specification.
                             items:
                               description: VolumeMount describes a mounting of a Volume
                                 within a container.
@@ -5499,7 +5509,8 @@ spec:
                         workload's pods.
                       type: object
                     podManagementPolicy:
-                      description: PodManagementPolicy By default, it is set to "parallel"
+                      default: Parallel
+                      description: PodManagementPolicy
                       type: string
                     ports:
                       description: Ports Extra ports to be added to pod spec.
@@ -5693,8 +5704,7 @@ spec:
                       minimum: 0
                       type: integer
                     resources:
-                      description: Resources Kubernetes Native resource requirements
-                        specification.
+                      description: Resources Kubernetes Native `resources` specification.
                       properties:
                         claims:
                           description: "Claims lists the names of resources, defined
@@ -9019,6 +9029,7 @@ spec:
                 description: PodLabels Custom labels to be populated in `Druid` pods.
                 type: object
               podManagementPolicy:
+                default: Parallel
                 description: PodManagementPolicy
                 type: string
               readinessProbe:
@@ -10028,7 +10039,7 @@ spec:
                     type: integer
                 type: object
               tolerations:
-                description: Tolerations Kubernetes native `toleration` specification.
+                description: Tolerations Kubernetes native `tolerations` specification.
                 items:
                   description: The pod this Toleration is attached to tolerates any
                     taint that matches the triple <key,value,effect> using the matching
@@ -10486,7 +10497,7 @@ spec:
                   type: object
                 type: array
               volumes:
-                description: Volumes Kubernetes Native `Volume` specification.
+                description: Volumes Kubernetes Native `Volumes` specification.
                 items:
                   description: Volume represents a named volume in a pod that may
                     be accessed by any container in the pod.

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1143,7 +1143,7 @@ func setLivenessProbe(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) *v1.P
 	livenessProbe := updateDefaultPortInProbe(
 		firstNonNilValue(nodeSpec.LivenessProbe, m.Spec.LivenessProbe).(*v1.Probe),
 		nodeSpec.DruidPort)
-	if livenessProbe == nil {
+	if livenessProbe == nil && m.Spec.DefaultProbes {
 		livenessProbe = setDefaultProbe(nodeSpec.DruidPort, nodeSpec.NodeType, probeType)
 	}
 	return livenessProbe
@@ -1154,7 +1154,7 @@ func setReadinessProbe(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) *v1.
 	readinessProbe := updateDefaultPortInProbe(
 		firstNonNilValue(nodeSpec.ReadinessProbe, m.Spec.ReadinessProbe).(*v1.Probe),
 		nodeSpec.DruidPort)
-	if readinessProbe == nil {
+	if readinessProbe == nil && m.Spec.DefaultProbes {
 		readinessProbe = setDefaultProbe(nodeSpec.DruidPort, nodeSpec.NodeType, probeType)
 	}
 	return readinessProbe
@@ -1165,7 +1165,7 @@ func setStartUpProbe(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) *v1.Pr
 	startUpProbe := updateDefaultPortInProbe(
 		firstNonNilValue(nodeSpec.StartUpProbes, m.Spec.StartUpProbe).(*v1.Probe),
 		nodeSpec.DruidPort)
-	if startUpProbe == nil {
+	if startUpProbe == nil && m.Spec.DefaultProbes {
 		startUpProbe = setDefaultProbe(nodeSpec.DruidPort, nodeSpec.NodeType, probeType)
 	}
 	return startUpProbe
@@ -1347,7 +1347,7 @@ func setDefaultProbe(defaultPort int32, nodeType string, probeType string) *v1.P
 	}
 
 	if nodeType == historical && probeType != "liveness" {
-		probe.HTTPGet.Path = "/druid/historical/v1/loadstatus"
+		probe.HTTPGet.Path = "/druid/historical/v1/readiness"
 		probe.FailureThreshold = 20
 	}
 	if nodeType == broker && probeType != "liveness" {

--- a/controllers/druid/handler_test.go
+++ b/controllers/druid/handler_test.go
@@ -36,6 +36,24 @@ var _ = Describe("Test handler", func() {
 
 			Expect(actual).Should(Equal(expected))
 		})
+		It("should make statefulset for broker without default probe", func() {
+			By("By making statefulset for broker")
+			filePath := "testdata/druid-test-cr-noprobe.yaml"
+			clusterSpec, err := readDruidClusterSpecFromFile(filePath)
+			Expect(err).Should(BeNil())
+
+			nodeSpecUniqueStr := makeNodeSpecificUniqueString(clusterSpec, "brokers")
+			nodeSpec := clusterSpec.Spec.Nodes["brokers"]
+
+			actual, _ := makeStatefulSet(&nodeSpec, clusterSpec, makeLabelsForNodeSpec(&nodeSpec, clusterSpec, clusterSpec.Name, nodeSpecUniqueStr), nodeSpecUniqueStr, "blah", nodeSpecUniqueStr)
+			addHashToObject(actual)
+
+			expected := new(appsv1.StatefulSet)
+			err = readAndUnmarshallResource("testdata/broker-statefulset-noprobe.yaml", &expected)
+			Expect(err).Should(BeNil())
+
+			Expect(actual).Should(Equal(expected))
+		})
 
 		It("should make statefulset for broker with sidecar", func() {
 			By("By making statefulset for broker with sidecar")

--- a/controllers/druid/testdata/broker-statefulset-noprobe.yaml
+++ b/controllers/druid/testdata/broker-statefulset-noprobe.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-druid-test-brokers
+  namespace: test-namespace
+  labels:
+    app: druid
+    druid_cr: druid-test
+    nodeSpecUniqueStr: druid-druid-test-brokers
+    component: broker
+  annotations:
+    druidOpResourceHash: SfMSTxw3YZTBJP0JKsd5ZBiGgkI=
+spec:
+  podManagementPolicy: Parallel
+  replicas: 2
+  selector:
+    matchLabels:
+      app: druid
+      druid_cr: druid-test
+      nodeSpecUniqueStr: druid-druid-test-brokers
+      component: broker
+  serviceName: druid-druid-test-brokers
+  template:
+    metadata:
+      labels:
+        app: druid
+        druid_cr: druid-test
+        nodeSpecUniqueStr: druid-druid-test-brokers
+        component: broker
+      annotations:
+        key1: value1
+        key2: value2
+    spec:
+      tolerations: []
+      affinity: {}
+      containers:
+        - command:
+            - bin/run-druid.sh
+            - broker
+          image: himanshu01/druid:druid-0.12.0-1
+          name: druid-druid-test-brokers
+          env:
+            - name: configMapSHA
+              value: blah
+          ports:
+            - containerPort: 8083
+              name: random
+          readinessProbe:
+            httpGet:
+              path: /status
+              port: 8080
+          resources:
+            limits:
+              cpu: "4"
+              memory: 2Gi
+            requests:
+              cpu: "4"
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /druid/conf/druid/_common
+              readOnly: true
+              name: common-config-volume
+            - mountPath: /druid/conf/druid/broker
+              readOnly: true
+              name: nodetype-config-volume
+            - mountPath: /druid/data
+              readOnly: true
+              name: data-volume
+      securityContext:
+        fsGroup: 107
+        runAsUser: 106
+      volumes:
+        - configMap:
+            name: druid-test-druid-common-config
+          name: common-config-volume
+        - configMap:
+            name: druid-druid-test-brokers-config
+          name: nodetype-config-volume
+  volumeClaimTemplates:
+    - metadata:
+        name: data-volume
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+        storageClassName: gp2

--- a/controllers/druid/testdata/druid-smoke-test-cluster.yaml
+++ b/controllers/druid/testdata/druid-smoke-test-cluster.yaml
@@ -8,6 +8,7 @@ spec:
   # Optionally specify image for all nodes. Can be specify on nodes also
   # imagePullSecrets:
   # - name: tutu
+  defaultProbes: true
   startScript: /druid.sh
   podLabels:
     environment: stage

--- a/controllers/druid/testdata/druid-test-cr-noprobe.yaml
+++ b/controllers/druid/testdata/druid-test-cr-noprobe.yaml
@@ -4,8 +4,8 @@ metadata:
   name: druid-test
   namespace: test-namespace
 spec:
-  image: apache/druid:0.22.1
-  defaultProbes: true
+  image: himanshu01/druid:druid-0.12.0-1
+  defaultProbes: false
   podAnnotations:
     key1: value1
     key2: value2
@@ -15,34 +15,6 @@ spec:
   readinessProbe:
     httpGet:
       path: /status
-  additionalContainer:
-    - image: universalforwarder-sidekick:next
-      containerName: forwarder
-      command:
-        - /bin/sidekick
-      imagePullPolicy: Always
-      securityContext:
-        runAsUser: 506
-      volumeMounts:
-        - name: logstore
-          mountPath: /logstore
-      env:
-        - name: SAMPLE_ENV
-          value: SAMPLE_VALUE
-      resources:
-        requests:
-          memory: "1Gi"
-          cpu: "500m"
-        limits:
-          memory: "1Gi"
-          cpu: "500m"
-      args:
-        - -loggingEnabled=true
-        - -dataCenter=dataCenter
-        - -environment=environment
-        - -application=application
-        - -instance=instance
-        - -logFiles=logFiles
   zookeeper:
     type: default
     spec:
@@ -69,66 +41,66 @@ spec:
         druid.s3.accessKey=accesskey
         druid.s3.secretKey=secretkey
   jvm.options: |-
-    -server
-    -XX:MaxDirectMemorySize=10240g
-    -Duser.timezone=UTC
-    -Dfile.encoding=UTF-8
-    -Dlog4j.debug
-    -XX:+ExitOnOutOfMemoryError
-    -XX:+HeapDumpOnOutOfMemoryError
-    -XX:+UseG1GC
-    -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
+      -server
+      -XX:MaxDirectMemorySize=10240g
+      -Duser.timezone=UTC
+      -Dfile.encoding=UTF-8
+      -Dlog4j.debug
+      -XX:+ExitOnOutOfMemoryError
+      -XX:+HeapDumpOnOutOfMemoryError
+      -XX:+UseG1GC
+      -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
   log4j.config: |-
-    <?xml version="1.0" encoding="UTF-8" ?>
-    <Configuration status="WARN">
-        <Appenders>
-            <Console name="Console" target="SYSTEM_OUT">
-                <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
-            </Console>
-        </Appenders>
-        <Loggers>
-            <Root level="info">
-                <AppenderRef ref="Console"/>
-            </Root>
-        </Loggers>
-    </Configuration>
+      <?xml version="1.0" encoding="UTF-8" ?>
+      <Configuration status="WARN">
+          <Appenders>
+              <Console name="Console" target="SYSTEM_OUT">
+                  <PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/>
+              </Console>
+          </Appenders>
+          <Loggers>
+              <Root level="info">
+                  <AppenderRef ref="Console"/>
+              </Root>
+          </Loggers>
+      </Configuration>
   common.runtime.properties: |-
-    #
-    # Extensions
-    #
-    druid.extensions.loadList=["druid-datasketches", "druid-s3-extensions", "postgresql-metadata-storage"]
-    
-    #
-    # Logging
-    #
-    # Log all runtime properties on startup. Disable to avoid logging properties on startup:
-    druid.startup.logging.logProperties=true
-    
-    #
-    # Indexing service logs
-    #
-    # Store indexing logs in an S3 bucket named 'druid-deep-storage' with the
-    # prefix 'druid/indexing-logs'
-    druid.indexer.logs.type=s3
-    druid.indexer.logs.s3Bucket=mybucket
-    druid.indexer.logs.s3Prefix=druid/indexing-logs
-    
-    #
-    # Service discovery
-    #
-    druid.selectors.indexing.serviceName=druid/overlord
-    druid.selectors.coordinator.serviceName=druid/coordinator
-    
-    #
-    # Monitoring
-    #
-    druid.monitoring.monitors=["com.metamx.metrics.JvmMonitor"]
-    druid.emitter=logging
-    druid.emitter.logging.logLevel=info
-    
-    # Storage type of double columns
-    # ommiting this will lead to index double as float at the storage layer
-    druid.indexing.doubleStorage=double
+      #
+      # Extensions
+      #
+      druid.extensions.loadList=["druid-datasketches", "druid-s3-extensions", "postgresql-metadata-storage"]
+
+      #
+      # Logging
+      #
+      # Log all runtime properties on startup. Disable to avoid logging properties on startup:
+      druid.startup.logging.logProperties=true
+
+      #
+      # Indexing service logs
+      #
+      # Store indexing logs in an S3 bucket named 'druid-deep-storage' with the
+      # prefix 'druid/indexing-logs'
+      druid.indexer.logs.type=s3
+      druid.indexer.logs.s3Bucket=mybucket
+      druid.indexer.logs.s3Prefix=druid/indexing-logs
+
+      #
+      # Service discovery
+      #
+      druid.selectors.indexing.serviceName=druid/overlord
+      druid.selectors.coordinator.serviceName=druid/coordinator
+
+      #
+      # Monitoring
+      #
+      druid.monitoring.monitors=["com.metamx.metrics.JvmMonitor"]
+      druid.emitter=logging
+      druid.emitter.logging.logLevel=info
+
+      # Storage type of double columns
+      # ommiting this will lead to index double as float at the storage layer
+      druid.indexing.doubleStorage=double
   metricDimensions.json: |-
     {
       "query/time" : { "dimensions" : ["dataSource", "type"], "type" : "timer"}
@@ -137,11 +109,11 @@ spec:
     brokers:
       nodeType: "broker"
       services:
-        -
+         -
           spec:
             type: ClusterIP
             clusterIP: None
-        -
+         -
           metadata:
             name: broker-%s-service
             annotations:
@@ -157,20 +129,17 @@ spec:
       replicas: 2
       podDisruptionBudgetSpec:
         maxUnavailable: 1
-      livenessProbe:
-        httpGet:
-          path: /status
       ports:
         -
           name: random
           containerPort: 8083
       runtime.properties: |-
         druid.service=druid/broker
-        
+
         # HTTP server threads
         druid.broker.http.numConnections=5
         druid.server.http.numThreads=25
-        
+
         # Processing threads and buffers
         druid.processing.buffer.sizeBytes=1
         druid.processing.numMergeBuffers=1
@@ -179,16 +148,16 @@ spec:
         -Xmx1G
         -Xms1G
       volumeClaimTemplates:
-        - metadata:
-            name: data-volume
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 2Gi
-            storageClassName: gp2
-      
+       - metadata:
+           name: data-volume
+         spec:
+           accessModes:
+           - ReadWriteOnce
+           resources:
+             requests:
+               storage: 2Gi
+           storageClassName: gp2
+
       volumeMounts:
         - mountPath: /druid/data
           name: data-volume
@@ -200,7 +169,7 @@ spec:
         limits:
           memory: "2Gi"
           cpu: "4"
-    
+
     coordinators:
       nodeType: "coordinator"
       druid.port: 8080
@@ -211,7 +180,7 @@ spec:
           containerPort: 8083
       runtime.properties: |-
         druid.service=druid/coordinator
-        
+
         # HTTP server threads
         druid.coordinator.startDelay=PT30S
         druid.coordinator.period=PT30S
@@ -219,16 +188,16 @@ spec:
         -Xmx1G
         -Xms1G
       volumeClaimTemplates:
-        - metadata:
-            name: data-volume
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 2Gi
-            storageClassName: gp2
-      
+       - metadata:
+           name: data-volume
+         spec:
+           accessModes:
+           - ReadWriteOnce
+           resources:
+             requests:
+               storage: 2Gi
+           storageClassName: gp2
+
       volumeMounts:
         - mountPath: /druid/data
           name: data-volume
@@ -239,7 +208,7 @@ spec:
         limits:
           memory: "2Gi"
           cpu: "4"
-    
+
     historicals:
       nodeType: "historical"
       druid.port: 8080
@@ -261,16 +230,16 @@ spec:
         -Xmx1G
         -Xms1G
       volumeClaimTemplates:
-        - metadata:
-            name: data-volume
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 2Gi
-            storageClassName: gp2
-      
+       - metadata:
+           name: data-volume
+         spec:
+           accessModes:
+           - ReadWriteOnce
+           resources:
+             requests:
+               storage: 2Gi
+           storageClassName: gp2
+
       volumeMounts:
         - mountPath: /druid/data
           name: data-volume
@@ -281,7 +250,7 @@ spec:
         limits:
           memory: "2Gi"
           cpu: "4"
-    
+
     overlords:
       nodeType: "overlord"
       druid.port: 8080
@@ -292,7 +261,7 @@ spec:
           containerPort: 8083
       runtime.properties: |-
         druid.service=druid/overlord
-        
+
         # HTTP server threads
         druid.indexer.queue.startDelay=PT30S
         druid.indexer.runner.type=remote
@@ -301,16 +270,16 @@ spec:
         -Xmx1G
         -Xms1G
       volumeClaimTemplates:
-        - metadata:
-            name: data-volume
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 2Gi
-            storageClassName: gp2
-      
+       - metadata:
+           name: data-volume
+         spec:
+           accessModes:
+           - ReadWriteOnce
+           resources:
+             requests:
+               storage: 2Gi
+           storageClassName: gp2
+
       volumeMounts:
         - mountPath: /druid/data
           name: data-volume
@@ -321,7 +290,7 @@ spec:
         limits:
           memory: "2Gi"
           cpu: "4"
-    
+
     middlemanagers:
       nodeType: "middleManager"
       druid.port: 8080
@@ -357,7 +326,7 @@ spec:
         -
           name: peon-9-pt
           containerPort: 8109
-      
+
       runtime.properties: |-
         druid.service=druid/middleManager
         druid.worker.capacity=1
@@ -373,16 +342,16 @@ spec:
         -Xmx1G
         -Xms1G
       volumeClaimTemplates:
-        - metadata:
-            name: data-volume
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 2Gi
-            storageClassName: gp2
-      
+       - metadata:
+           name: data-volume
+         spec:
+           accessModes:
+           - ReadWriteOnce
+           resources:
+             requests:
+               storage: 2Gi
+           storageClassName: gp2
+
       volumeMounts:
         - mountPath: /druid/data
           name: data-volume

--- a/controllers/druid/testdata/druid-test-cr.yaml
+++ b/controllers/druid/testdata/druid-test-cr.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: test-namespace
 spec:
   image: himanshu01/druid:druid-0.12.0-1
+  defaultProbes: true
   podAnnotations:
     key1: value1
     key2: value2

--- a/docs/api_specifications/druid.md
+++ b/docs/api_specifications/druid.md
@@ -12,6 +12,7 @@ Resource Types:
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#druid.apache.org/v1alpha1.DruidNodeSpec">DruidNodeSpec</a>, 
 <a href="#druid.apache.org/v1alpha1.DruidSpec">DruidSpec</a>)
 </p>
 <p>AdditionalContainer defines additional sidecar containers to be deployed with the <code>Druid</code> pods.
@@ -47,7 +48,7 @@ string
 </em>
 </td>
 <td>
-<p>Image</p>
+<p>Image Image of the additional container.</p>
 </td>
 </tr>
 <tr>
@@ -69,7 +70,7 @@ string
 </em>
 </td>
 <td>
-<p>Command</p>
+<p>Command command for the additional container.</p>
 </td>
 </tr>
 <tr>
@@ -83,7 +84,7 @@ Kubernetes core/v1.PullPolicy
 </td>
 <td>
 <em>(Optional)</em>
-<p>ImagePullPolicy If not present, will be taken from top level spec</p>
+<p>ImagePullPolicy If not present, will be taken from top level spec.</p>
 </td>
 </tr>
 <tr>
@@ -123,7 +124,7 @@ Kubernetes core/v1.ResourceRequirements
 </td>
 <td>
 <em>(Optional)</em>
-<p>Resources Kubernetes Native resource requirements specification.</p>
+<p>Resources Kubernetes Native <code>resources</code> specification.</p>
 </td>
 </tr>
 <tr>
@@ -137,7 +138,7 @@ Kubernetes core/v1.ResourceRequirements
 </td>
 <td>
 <em>(Optional)</em>
-<p>VolumeMounts Kubernetes Native volume mounts specification.</p>
+<p>VolumeMounts Kubernetes Native <code>VolumeMount</code> specification.</p>
 </td>
 </tr>
 <tr>
@@ -219,7 +220,7 @@ encoding/json.RawMessage
 </div>
 <h3 id="druid.apache.org/v1alpha1.Druid">Druid
 </h3>
-<p>Druid is the Schema for the druids API</p>
+<p>Druid is the Schema for the druids API.</p>
 <div class="md-typeset__scrollwrap">
 <div class="md-typeset__table">
 <table>
@@ -541,7 +542,7 @@ Kubernetes core/v1.SecurityContext
 </td>
 <td>
 <em>(Optional)</em>
-<p>Volumes Kubernetes Native <code>Volume</code> specification.</p>
+<p>Volumes Kubernetes Native <code>Volumes</code> specification.</p>
 </td>
 </tr>
 <tr>
@@ -677,7 +678,7 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Tolerations Kubernetes native <code>toleration</code> specification.</p>
+<p>Tolerations Kubernetes native <code>tolerations</code> specification.</p>
 </td>
 </tr>
 <tr>
@@ -699,7 +700,7 @@ Kubernetes core/v1.Affinity
 <code>nodes</code><br>
 <em>
 <a href="#druid.apache.org/v1alpha1.DruidNodeSpec">
-map[string]druid-operator/apis/druid/v1alpha1.DruidNodeSpec
+map[string]./apis/druid/v1alpha1.DruidNodeSpec
 </a>
 </em>
 </td>
@@ -736,6 +737,19 @@ bool
 <a href="https://druid.apache.org/docs/latest/operations/rolling-updates.html">https://druid.apache.org/docs/latest/operations/rolling-updates.html</a>
 If set to true then operator checks the rollout status of previous version workloads before updating the next.
 This will be done only for update actions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>defaultProbes</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DefaultProbes If set to true this will add default probes (liveness / readiness / startup) for all druid components
+but it won&rsquo;t override existing probes</p>
 </td>
 </tr>
 <tr>
@@ -789,7 +803,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>DimensionsMapPath Custom Dimension Map Path for statsd emitter.</p>
+<p>DimensionsMapPath Custom Dimension Map Path for statsd emitter.
+stastd documentation is described in the following documentation:
+<a href="https://druid.apache.org/docs/latest/development/extensions-contrib/statsd.html">https://druid.apache.org/docs/latest/development/extensions-contrib/statsd.html</a></p>
 </td>
 </tr>
 <tr>
@@ -1277,7 +1293,7 @@ Kubernetes core/v1.ResourceRequirements
 </td>
 <td>
 <em>(Optional)</em>
-<p>Resources Kubernetes Native resource requirements specification.</p>
+<p>Resources Kubernetes Native <code>resources</code> specification.</p>
 </td>
 </tr>
 <tr>
@@ -1331,7 +1347,7 @@ Kubernetes apps/v1.PodManagementPolicyType
 </td>
 <td>
 <em>(Optional)</em>
-<p>PodManagementPolicy By default, it is set to &ldquo;parallel&rdquo;</p>
+<p>PodManagementPolicy</p>
 </td>
 </tr>
 <tr>
@@ -1540,6 +1556,20 @@ Kubernetes autoscaling/v2.HorizontalPodAutoscalerSpec
 <td>
 <em>(Optional)</em>
 <p>Volumes Kubernetes Native <code>volumes</code> specification.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>additionalContainer</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.AdditionalContainer">
+[]AdditionalContainer
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Operator deploys the sidecar container based on these properties.</p>
 </td>
 </tr>
 </tbody>
@@ -1911,7 +1941,7 @@ Kubernetes core/v1.SecurityContext
 </td>
 <td>
 <em>(Optional)</em>
-<p>Volumes Kubernetes Native <code>Volume</code> specification.</p>
+<p>Volumes Kubernetes Native <code>Volumes</code> specification.</p>
 </td>
 </tr>
 <tr>
@@ -2047,7 +2077,7 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Tolerations Kubernetes native <code>toleration</code> specification.</p>
+<p>Tolerations Kubernetes native <code>tolerations</code> specification.</p>
 </td>
 </tr>
 <tr>
@@ -2069,7 +2099,7 @@ Kubernetes core/v1.Affinity
 <code>nodes</code><br>
 <em>
 <a href="#druid.apache.org/v1alpha1.DruidNodeSpec">
-map[string]druid-operator/apis/druid/v1alpha1.DruidNodeSpec
+map[string]./apis/druid/v1alpha1.DruidNodeSpec
 </a>
 </em>
 </td>
@@ -2106,6 +2136,19 @@ bool
 <a href="https://druid.apache.org/docs/latest/operations/rolling-updates.html">https://druid.apache.org/docs/latest/operations/rolling-updates.html</a>
 If set to true then operator checks the rollout status of previous version workloads before updating the next.
 This will be done only for update actions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>defaultProbes</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DefaultProbes If set to true this will add default probes (liveness / readiness / startup) for all druid components
+but it won&rsquo;t override existing probes</p>
 </td>
 </tr>
 <tr>
@@ -2159,7 +2202,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>DimensionsMapPath Custom Dimension Map Path for statsd emitter.</p>
+<p>DimensionsMapPath Custom Dimension Map Path for statsd emitter.
+stastd documentation is described in the following documentation:
+<a href="https://druid.apache.org/docs/latest/development/extensions-contrib/statsd.html">https://druid.apache.org/docs/latest/development/extensions-contrib/statsd.html</a></p>
 </td>
 </tr>
 <tr>

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,13 +3,13 @@
 - [Deny List in Operator](#deny-list-in-operator)
 - [Reconcile Time in Operator](#reconcile-time-in-operator)
 - [Finalizer in Druid CR](#finalizer-in-druid-cr)
-- [Deletetion of Orphan PVC's](#deletetion-of-orphan-pvcs)
+- [Deletion of Orphan PVCs](#deletion-of-orphan-pvcs)
 - [Rolling Deploy](#rolling-deploy)
 - [Force Delete of Sts Pods](#force-delete-of-sts-pods)
-- [Scaling of Druid Nodes](#scaling-of-druid-nodes)
-- [Volume Expansion of Druid Nodes Running As StatefulSets](#volume-expansion-of-druid-nodes-running-as-statefulsets)
-- [Add Additional Containers in Druid Nodes](#add-additional-containers-in-druid-nodes)
-- [Setup default probe by default](#setup-default-probe-by-default)
+- [Horizontal Scaling of Druid Pods](#horizontal-scaling-of-druid-pods)
+- [Volume Expansion of Druid Pods Running As StatefulSets](#volume-expansion-of-druid-pods-running-as-statefulsets)
+- [Add Additional Containers to Druid Pods](#add-additional-containers-to-druid-pods)
+- [Default Yet Configurable Probes](#default-yet-configurable-probes)
 
 
 ## Deny List in Operator
@@ -110,7 +110,13 @@ There are two scopes you can add additional container:
 ## Default Yet Configurable Probes
 The operator create the Deployments and StatefulSets with a default set of probes for each druid components.
 These probes can be overriden by adding one of the probes in the `DruidSpec` (global) or under the
-`NodeSpec` (component-scope). 
+`NodeSpec` (component-scope).
+
+This feature is enabled by default.
+
+:warning: Disable this feature by settings : `defaultProbes: false` if you have the `kubernetes-overlord-extensions` enabled also named [middle manager less druid in k8s](https://druid.apache.org/docs/latest/development/extensions-contrib/k8s-jobs/)
+more details are described here: https://github.com/datainfrahq/druid-operator/issues/97#issuecomment-1687048907
+
 All the probes definitions are documented bellow:
 
 <details>
@@ -201,7 +207,7 @@ All the probes definitions are documented bellow:
   readinessProbe:
     failureThreshold: 20
     httpGet:
-      path: /druid/historical/v1/loadstatus
+      path: /druid/historical/v1/readiness
       port: $druid.port
     initialDelaySeconds: 5
     periodSeconds: 10
@@ -210,7 +216,7 @@ All the probes definitions are documented bellow:
   startupProbe:
     failureThreshold: 20
     httpGet:
-      path: /druid/historical/v1/loadstatus
+      path: /druid/historical/v1/readiness
       port: $druid.port
     initialDelaySeconds: 180
     periodSeconds: 30


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #97 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

1. change historical readiness path to `/druid/historical/v1/readiness`  
  Both path has similar purpose. https://druid.apache.org/docs/latest/operations/api-reference/#historical
  ```
  Similar to /druid/historical/v1/loadstatus, but instead of returning JSON with a flag, responses 200 OK if segments in the local cache have been loaded, and 503 SERVICE UNAVAILABLE, if they haven't.
  ```
2. add defaultProbes bool in druid spec to true by default 
3. update docs and document the issue with middle manager less until we add test case and a fix

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `controllers/druid/handler.go`
 * `docs/features.md`
 *  `chart/templates/crds/druid.apache.org_druids.yaml`
 * `config/crd/bases/druid.apache.org_druids.yaml`

