### PR TITLE
Update README.md to mark v1.0.0 as compatible with k8s 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Feel free to join Kubernetes slack and join [druid-operator](https://kubernetes.
 | :------------- | :-------------: | :-----: | :---: |
 | kubernetes <= 1.20 | :x:| :x: | :x: |
 | kubernetes == 1.21 | :white_check_mark:| :x: | :x: |
-| kubernetes >= 1.22 and < 1.25 | :white_check_mark: | :white_check_mark: | :x: |
+| kubernetes >= 1.22 and <= 1.25 | :white_check_mark: | :white_check_mark: | :x: |
 | kubernetes > 1.25 | :x: | :x: | :white_check_mark: |
 
 ### Commerical Support


### PR DESCRIPTION
Touch up Readme.md to make clear that 1.25 is compatible with v1.0.0

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
