### PR TITLE
The CRD in Helmchart 0.3.3 lacked compatibility with operator 1.2.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/e2e/configs/druid-cr.yaml
+++ b/e2e/configs/druid-cr.yaml
@@ -17,10 +17,11 @@ spec:
     httpGet:
       path: /status/health
       port: 8088
+  defaultProbes: true
   additionalContainer:
   - containerName: mysqlconnector 
     runAsInit: true
-    image: apache/druid:25.0.0
+    image: apache/druid:27.0.0
     command:
     - "sh"
     - "-c"


### PR DESCRIPTION
### Description

The CRD in current helmchart 0.3.3 doesn't support new `defaultProbes`flag because it's missing the updated CRD. On main branch correct CRD is already part the chart templates. Just version bump and new chart release is needed. 

Proof: https://github.com/datainfrahq/druid-operator/compare/v1.2.0...master#diff-ac89862766e3f77344510231ecae143de9dbc50a223735dbbc10dc17a56a6ff1R1518 

![image](https://github.com/datainfrahq/druid-operator/assets/8415907/b71742c1-8c1d-4aa9-af85-c80d21250b76)

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `chart/Chart.yaml`

