### PR TITLE
fix: made the startup probe consistent for nodespec and druidspec

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -425,9 +425,9 @@ type DruidNodeSpec struct {
 	// +optional
 	ReadinessProbe *v1.Probe `json:"readinessProbe,omitempty"`
 
-	// StartUpProbes
+	// StartUpProbe
 	// +optional
-	StartUpProbes *v1.Probe `json:"startUpProbes,omitempty"`
+	StartUpProbe *v1.Probe `json:"startUpProbe,omitempty"`
 
 	// IngressAnnotations `Ingress` annotations to be populated in ingress spec.
 	// +optional

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -336,8 +336,8 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 		*out = new(v1.Probe)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.StartUpProbes != nil {
-		in, out := &in.StartUpProbes, &out.StartUpProbes
+	if in.StartUpProbe != nil {
+		in, out := &in.StartUpProbe, &out.StartUpProbe
 		*out = new(v1.Probe)
 		(*in).DeepCopyInto(*out)
 	}

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -6512,8 +6512,8 @@ spec:
                             type: object
                         type: object
                       type: array
-                    startUpProbes:
-                      description: StartUpProbes
+                    startUpProbe:
+                      description: StartUpProbe
                       properties:
                         exec:
                           description: Exec specifies the action to take.

--- a/config/crd/bases/druid.apache.org_druids.yaml
+++ b/config/crd/bases/druid.apache.org_druids.yaml
@@ -6512,8 +6512,8 @@ spec:
                             type: object
                         type: object
                       type: array
-                    startUpProbes:
-                      description: StartUpProbes
+                    startUpProbe:
+                      description: StartUpProbe
                       properties:
                         exec:
                           description: Exec specifies the action to take.

--- a/config/druid.apache.org_druids.yaml
+++ b/config/druid.apache.org_druids.yaml
@@ -5926,7 +5926,7 @@ spec:
                             type: object
                         type: object
                       type: array
-                    startUpProbes:
+                    startUpProbe:
                       description: StartupProbe for nodeSpec
                       properties:
                         exec:

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1043,7 +1043,7 @@ func setReadinessProbe(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) *v1.
 func setStartUpProbe(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) *v1.Probe {
 	probeType := "startup"
 	startUpProbe := updateDefaultPortInProbe(
-		firstNonNilValue(nodeSpec.StartUpProbes, m.Spec.StartUpProbe).(*v1.Probe),
+		firstNonNilValue(nodeSpec.StartUpProbe, m.Spec.StartUpProbe).(*v1.Probe),
 		nodeSpec.DruidPort)
 	if startUpProbe == nil && m.Spec.DefaultProbes {
 		startUpProbe = setDefaultProbe(nodeSpec.DruidPort, nodeSpec.NodeType, probeType)

--- a/docs/api_specifications/druid.md
+++ b/docs/api_specifications/druid.md
@@ -1446,7 +1446,7 @@ Port is set to <code>druid.port</code> if not specified with httpGet handler.</p
 </tr>
 <tr>
 <td>
-<code>startUpProbes</code><br>
+<code>startUpProbe</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#probe-v1-core">
 Kubernetes core/v1.Probe
@@ -1455,7 +1455,7 @@ Kubernetes core/v1.Probe
 </td>
 <td>
 <em>(Optional)</em>
-<p>StartUpProbes</p>
+<p>StartUpProbe</p>
 </td>
 </tr>
 <tr>

--- a/e2e/configs/druid-mmless.yaml
+++ b/e2e/configs/druid-mmless.yaml
@@ -206,7 +206,7 @@ spec:
         periodSeconds: 10
         successThreshold: 1
         timeoutSeconds: 5
-      startUpProbes:
+      startUpProbe:
         failureThreshold: 20
         httpGet:
           path: /druid/historical/v1/loadstatus
@@ -272,7 +272,7 @@ spec:
         periodSeconds: 10
         successThreshold: 1
         timeoutSeconds: 5
-      startUpProbes:
+      startUpProbe:
         failureThreshold: 20
         httpGet:
           path: /druid/historical/v1/loadstatus

--- a/examples/tiny-cluster-mmless.yaml
+++ b/examples/tiny-cluster-mmless.yaml
@@ -208,7 +208,7 @@ spec:
         periodSeconds: 10
         successThreshold: 1
         timeoutSeconds: 5
-      startUpProbes:
+      startUpProbe:
         failureThreshold: 20
         httpGet:
           path: /druid/historical/v1/loadstatus
@@ -274,7 +274,7 @@ spec:
         periodSeconds: 10
         successThreshold: 1
         timeoutSeconds: 5
-      startUpProbes:
+      startUpProbe:
         failureThreshold: 20
         httpGet:
           path: /druid/historical/v1/loadstatus


### PR DESCRIPTION
Fixes #119 

### Description
Made the spelling of startup probe config consistent for nodeSpec and druidSpec. 

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `apis/druid/v1alpha1/druid_types.go`
 * `apis/druid/v1alpha1/zz_generated.deepcopy.go`
 * `chart/templates/crds/druid.apache.org_druids.yaml`
 * `config/crd/bases/druid.apache.org_druids.yaml`
 * `config/druid.apache.org_druids.yaml`
 * `controllers/druid/handler.go`
 * `docs/api_specifications/druid.md`
 * `e2e/configs/druid-mmless.yaml`
 * `examples/tiny-cluster-mmless.yaml`
