### PR TITLE
fix multinamespace cache isue

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -x
 # Get Kind
-go install sigs.k8s.io/kind@v0.17.0
+go install sigs.k8s.io/kind@v0.21.0
 # minio statefulset name
 MINIO_STS_NAME=myminio-ss-0
 # druid namespace
@@ -45,7 +45,7 @@ kubectl apply -f e2e/configs/druid-cr.yaml -n ${NAMESPACE}
 sleep 10
 for d in $(kubectl get pods -n ${NAMESPACE} -l app=druid -l druid_cr=tiny-cluster -o name)
 do
-  kubectl wait -n ${NAMESPACE} "$d" --for=condition=Ready --timeout=5m
+  kubectl wait -n ${NAMESPACE} "$d" --for=condition=Ready --timeout=15m
 done
 # wait for druid pods
 for s in $(kubectl get sts -n ${NAMESPACE} -l app=${NAMESPACE} -l druid_cr=tiny-cluster -o name)

--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "e6946145.apache.org",
+		Namespace:              os.Getenv("WATCH_NAMESPACE"),
 		NewCache:               watchNamespaceCache(),
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the

--- a/main.go
+++ b/main.go
@@ -75,7 +75,6 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "e6946145.apache.org",
-		Namespace:              os.Getenv("WATCH_NAMESPACE"),
 		NewCache:               watchNamespaceCache(),
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
@@ -118,8 +117,9 @@ func main() {
 
 func watchNamespaceCache() cache.NewCacheFunc {
 	var managerWatchCache cache.NewCacheFunc
-	if watchNamespace != "" {
-		ns := strings.Split(watchNamespace, ",")
+	ns := strings.Split(watchNamespace, ",")
+
+	if len(ns) > 1 {
 		for i := range ns {
 			ns[i] = strings.TrimSpace(ns[i])
 		}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

@itamar-marom can you help in reviewing this one. 


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

```
adheipsingh@Adheips-Air ~ % k logs -f cluster-druid-operator-6c7b966548-rj58x  -n druid-operator-system -c manager
2024-02-09T15:24:02Z	ERROR	setup	unable to start manager	{"error": "must specify more than one namespace to use multi-namespace cache"}
main.main
	/workspace/main.go:93
runtime.main
	/usr/local/go/src/runtime/proc.go:250
```
- This issue arises when we have both ```Namespace``` and ```NewCache``` enabled for a single namespace to watch. 
- This PR add a check in watchNamespaceCache() to built cache only if multiple namespace are found, so runtime can default to watch namespace for single and NO namespace specified to watch. 
<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
