### PR TITLE
Bump controller-tools version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.11.2
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 GEN_CRD_API_REF_VERSION ?= v0.3.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"


### PR DESCRIPTION
### Description

Attempted to follow the instructions in the _**Running Operator Locally**_ section of the developer documentation. When I attempted to run `make install` I encountered a nil pointer dereference error. (See stack trace below.)

Looking into the stack trace I realised the error originated from the `controller-gen` command from the **controller-tools** package. Looking into said package, I realised that the latest released version is `v.0.14.0`. The version referenced in `Makefile` were `v0.11.2`. I tried to change the referenced version to the latest version and it solved the nil pointer dereferenced issue and I could continue following the developer documentation.

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `Makefile`
