### PR TITLE
Add support for annotations on Deployment/StatefulSet resources in DruidNodeSpec

### DIFF
--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -180,6 +180,11 @@ type DruidSpec struct {
 	// +optional
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 
+	// ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.
+	// if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec ReplicationControllerAnnotations will take precedence.
+	// +optional
+	ReplicationControllerAnnotations map[string]string `json:"replicationControllerAnnotations,omitempty"`
+
 	// PodManagementPolicy
 	// +optional
 	// +kubebuilder:default:="Parallel"

--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -180,10 +180,10 @@ type DruidSpec struct {
 	// +optional
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 
-	// ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.
-	// if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec ReplicationControllerAnnotations will take precedence.
+	// WorkloadAnnotations annotations to be populated in StatefulSet or Deployment spec.
+	// if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec WorkloadAnnotations will take precedence.
 	// +optional
-	ReplicationControllerAnnotations map[string]string `json:"replicationControllerAnnotations,omitempty"`
+	WorkloadAnnotations map[string]string `json:"workloadAnnotations,omitempty"`
 
 	// PodManagementPolicy
 	// +optional
@@ -438,9 +438,9 @@ type DruidNodeSpec struct {
 	// +optional
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
 
-	// ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.
+	// WorkloadAnnotations annotations to be populated in StatefulSet or Deployment spec.
 	// +optional
-	ReplicationControllerAnnotations map[string]string `json:"replicationControllerAnnotations,omitempty"`
+	WorkloadAnnotations map[string]string `json:"workloadAnnotations,omitempty"`
 
 	// Ingress Kubernetes Native `Ingress` specification.
 	// +optional

--- a/apis/druid/v1alpha1/druid_types.go
+++ b/apis/druid/v1alpha1/druid_types.go
@@ -433,6 +433,10 @@ type DruidNodeSpec struct {
 	// +optional
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
 
+	// ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.
+	// +optional
+	ReplicationControllerAnnotations map[string]string `json:"replicationControllerAnnotations,omitempty"`
+
 	// Ingress Kubernetes Native `Ingress` specification.
 	// +optional
 	Ingress *networkingv1.IngressSpec `json:"ingress,omitempty"`

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -456,8 +456,8 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.ReplicationControllerAnnotations != nil {
-		in, out := &in.ReplicationControllerAnnotations, &out.ReplicationControllerAnnotations
+	if in.WorkloadAnnotations != nil {
+		in, out := &in.WorkloadAnnotations, &out.WorkloadAnnotations
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
@@ -618,8 +618,8 @@ func (in *DruidSpec) DeepCopyInto(out *DruidSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.ReplicationControllerAnnotations != nil {
-		in, out := &in.ReplicationControllerAnnotations, &out.ReplicationControllerAnnotations
+	if in.WorkloadAnnotations != nil {
+		in, out := &in.WorkloadAnnotations, &out.WorkloadAnnotations
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -456,6 +456,13 @@ func (in *DruidNodeSpec) DeepCopyInto(out *DruidNodeSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ReplicationControllerAnnotations != nil {
+		in, out := &in.ReplicationControllerAnnotations, &out.ReplicationControllerAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Ingress != nil {
 		in, out := &in.Ingress, &out.Ingress
 		*out = new(networkingv1.IngressSpec)

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -618,6 +618,13 @@ func (in *DruidSpec) DeepCopyInto(out *DruidSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ReplicationControllerAnnotations != nil {
+		in, out := &in.ReplicationControllerAnnotations, &out.ReplicationControllerAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.PodLabels != nil {
 		in, out := &in.PodLabels, &out.PodLabels
 		*out = make(map[string]string, len(*in))

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -5715,6 +5715,12 @@ spec:
                       format: int32
                       minimum: 0
                       type: integer
+                    replicationControllerAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: ReplicationControllerAnnotations annotations to
+                        be populated in StatefulSet or Deployment spec.
+                      type: object
                     resources:
                       description: Resources Kubernetes Native `resources` specification.
                       properties:

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -9203,6 +9203,14 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              replicationControllerAnnotations:
+                additionalProperties:
+                  type: string
+                description: ReplicationControllerAnnotations annotations to be populated
+                  in StatefulSet or Deployment spec. if the same key is specified
+                  at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec
+                  ReplicationControllerAnnotations will take precedence.
+                type: object
               rollingDeploy:
                 default: true
                 description: 'RollingDeploy Whether to deploy the components in a

--- a/chart/templates/crds/druid.apache.org_druids.yaml
+++ b/chart/templates/crds/druid.apache.org_druids.yaml
@@ -5715,12 +5715,6 @@ spec:
                       format: int32
                       minimum: 0
                       type: integer
-                    replicationControllerAnnotations:
-                      additionalProperties:
-                        type: string
-                      description: ReplicationControllerAnnotations annotations to
-                        be populated in StatefulSet or Deployment spec.
-                      type: object
                     resources:
                       description: Resources Kubernetes Native `resources` specification.
                       properties:
@@ -9031,6 +9025,12 @@ spec:
                         - name
                         type: object
                       type: array
+                    workloadAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: WorkloadAnnotations annotations to be populated
+                        in StatefulSet or Deployment spec.
+                      type: object
                   required:
                   - druid.port
                   - nodeConfigMountPath
@@ -9202,14 +9202,6 @@ spec:
                       Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                     format: int32
                     type: integer
-                type: object
-              replicationControllerAnnotations:
-                additionalProperties:
-                  type: string
-                description: ReplicationControllerAnnotations annotations to be populated
-                  in StatefulSet or Deployment spec. if the same key is specified
-                  at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec
-                  ReplicationControllerAnnotations will take precedence.
                 type: object
               rollingDeploy:
                 default: true
@@ -12108,6 +12100,14 @@ spec:
                   - name
                   type: object
                 type: array
+              workloadAnnotations:
+                additionalProperties:
+                  type: string
+                description: WorkloadAnnotations annotations to be populated in StatefulSet
+                  or Deployment spec. if the same key is specified at both the DruidNodeSpec
+                  level and DruidSpec level, the DruidNodeSpec WorkloadAnnotations
+                  will take precedence.
+                type: object
               zookeeper:
                 description: 'Zookeeper IGNORED (Future API): In order to make Druid
                   dependency setup extensible from within Druid operator.'

--- a/config/crd/bases/druid.apache.org_druids.yaml
+++ b/config/crd/bases/druid.apache.org_druids.yaml
@@ -5715,6 +5715,12 @@ spec:
                       format: int32
                       minimum: 0
                       type: integer
+                    replicationControllerAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: ReplicationControllerAnnotations annotations to
+                        be populated in StatefulSet or Deployment spec.
+                      type: object
                     resources:
                       description: Resources Kubernetes Native `resources` specification.
                       properties:

--- a/config/crd/bases/druid.apache.org_druids.yaml
+++ b/config/crd/bases/druid.apache.org_druids.yaml
@@ -9203,6 +9203,14 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              replicationControllerAnnotations:
+                additionalProperties:
+                  type: string
+                description: ReplicationControllerAnnotations annotations to be populated
+                  in StatefulSet or Deployment spec. if the same key is specified
+                  at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec
+                  ReplicationControllerAnnotations will take precedence.
+                type: object
               rollingDeploy:
                 default: true
                 description: 'RollingDeploy Whether to deploy the components in a

--- a/config/crd/bases/druid.apache.org_druids.yaml
+++ b/config/crd/bases/druid.apache.org_druids.yaml
@@ -5715,12 +5715,6 @@ spec:
                       format: int32
                       minimum: 0
                       type: integer
-                    replicationControllerAnnotations:
-                      additionalProperties:
-                        type: string
-                      description: ReplicationControllerAnnotations annotations to
-                        be populated in StatefulSet or Deployment spec.
-                      type: object
                     resources:
                       description: Resources Kubernetes Native `resources` specification.
                       properties:
@@ -9031,6 +9025,12 @@ spec:
                         - name
                         type: object
                       type: array
+                    workloadAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: WorkloadAnnotations annotations to be populated
+                        in StatefulSet or Deployment spec.
+                      type: object
                   required:
                   - druid.port
                   - nodeConfigMountPath
@@ -9202,14 +9202,6 @@ spec:
                       Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                     format: int32
                     type: integer
-                type: object
-              replicationControllerAnnotations:
-                additionalProperties:
-                  type: string
-                description: ReplicationControllerAnnotations annotations to be populated
-                  in StatefulSet or Deployment spec. if the same key is specified
-                  at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec
-                  ReplicationControllerAnnotations will take precedence.
                 type: object
               rollingDeploy:
                 default: true
@@ -12108,6 +12100,14 @@ spec:
                   - name
                   type: object
                 type: array
+              workloadAnnotations:
+                additionalProperties:
+                  type: string
+                description: WorkloadAnnotations annotations to be populated in StatefulSet
+                  or Deployment spec. if the same key is specified at both the DruidNodeSpec
+                  level and DruidSpec level, the DruidNodeSpec WorkloadAnnotations
+                  will take precedence.
+                type: object
               zookeeper:
                 description: 'Zookeeper IGNORED (Future API): In order to make Druid
                   dependency setup extensible from within Druid operator.'

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -998,9 +998,10 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s", nodeSpecUniqueStr),
-			Namespace: m.Namespace,
-			Labels:    ls,
+			Name:        fmt.Sprintf("%s", nodeSpecUniqueStr),
+			Annotations: nodeSpec.ReplicationControllerAnnotations,
+			Namespace:   m.Namespace,
+			Labels:      ls,
 		},
 		Spec: makeStatefulSetSpec(nodeSpec, m, ls, nodeSpecUniqueStr, configMapSHA, serviceName),
 	}, nil
@@ -1022,9 +1023,10 @@ func makeDeployment(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s", nodeSpecUniqueStr),
-			Namespace: m.Namespace,
-			Labels:    ls,
+			Name:        fmt.Sprintf("%s", nodeSpecUniqueStr),
+			Annotations: nodeSpec.ReplicationControllerAnnotations,
+			Namespace:   m.Namespace,
+			Labels:      ls,
 		},
 		Spec: makeDeploymentSpec(nodeSpec, m, ls, nodeSpecUniqueStr, configMapSHA, serviceName),
 	}, nil

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1294,11 +1294,11 @@ func makeLabelsForNodeSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, 
 func makeAnnotationsForReplicationController(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) map[string]string {
 	var annotations = map[string]string{}
 
-	if nodeSpec.ReplicationControllerAnnotations != nil && m.Spec.ReplicationControllerAnnotations != nil {
-		annotations = m.Spec.ReplicationControllerAnnotations
+	if m.Spec.WorkloadAnnotations != nil {
+		annotations = m.Spec.WorkloadAnnotations
 	}
 
-	for k, v := range nodeSpec.ReplicationControllerAnnotations {
+	for k, v := range nodeSpec.WorkloadAnnotations {
 		annotations[k] = v
 	}
 

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -999,7 +999,7 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%s", nodeSpecUniqueStr),
-			Annotations: makeAnnotationsForReplicationController(nodeSpec, m),
+			Annotations: makeAnnotationsForWorkload(nodeSpec, m),
 			Namespace:   m.Namespace,
 			Labels:      ls,
 		},
@@ -1024,7 +1024,7 @@ func makeDeployment(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%s", nodeSpecUniqueStr),
-			Annotations: makeAnnotationsForReplicationController(nodeSpec, m),
+			Annotations: makeAnnotationsForWorkload(nodeSpec, m),
 			Namespace:   m.Namespace,
 			Labels:      ls,
 		},
@@ -1289,9 +1289,9 @@ func makeLabelsForNodeSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, 
 	return labels
 }
 
-// makeAnnotationsForReplicationController returns the annotations for a Deployment or StatefulSet
+// makeAnnotationsForWorkload returns the annotations for a Deployment or StatefulSet
 // If a given key is set in both the DruidSpec and DruidNodeSpec, the node-scoped value will take precedence.
-func makeAnnotationsForReplicationController(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) map[string]string {
+func makeAnnotationsForWorkload(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) map[string]string {
 	var annotations = map[string]string{}
 
 	if m.Spec.WorkloadAnnotations != nil {

--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -999,7 +999,7 @@ func makeStatefulSet(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%s", nodeSpecUniqueStr),
-			Annotations: nodeSpec.ReplicationControllerAnnotations,
+			Annotations: makeAnnotationsForReplicationController(nodeSpec, m),
 			Namespace:   m.Namespace,
 			Labels:      ls,
 		},
@@ -1024,7 +1024,7 @@ func makeDeployment(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, ls map[
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%s", nodeSpecUniqueStr),
-			Annotations: nodeSpec.ReplicationControllerAnnotations,
+			Annotations: makeAnnotationsForReplicationController(nodeSpec, m),
 			Namespace:   m.Namespace,
 			Labels:      ls,
 		},
@@ -1287,6 +1287,22 @@ func makeLabelsForNodeSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, 
 	labels["nodeSpecUniqueStr"] = nodeSpecUniqueStr
 	labels["component"] = nodeSpec.NodeType
 	return labels
+}
+
+// makeAnnotationsForReplicationController returns the annotations for a Deployment or StatefulSet
+// If a given key is set in both the DruidSpec and DruidNodeSpec, the node-scoped value will take precedence.
+func makeAnnotationsForReplicationController(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid) map[string]string {
+	var annotations = map[string]string{}
+
+	if nodeSpec.ReplicationControllerAnnotations != nil && m.Spec.ReplicationControllerAnnotations != nil {
+		annotations = m.Spec.ReplicationControllerAnnotations
+	}
+
+	for k, v := range nodeSpec.ReplicationControllerAnnotations {
+		annotations[k] = v
+	}
+
+	return annotations
 }
 
 // addOwnerRefToObject appends the desired OwnerReference to the object

--- a/controllers/druid/testdata/broker-deployment.yaml
+++ b/controllers/druid/testdata/broker-deployment.yaml
@@ -9,8 +9,10 @@ metadata:
     nodeSpecUniqueStr: druid-druid-test-brokers
     component: broker
   annotations:
-    druidOpResourceHash: 3UqXvm9M4F36B6t2qb8/tz8zfCg=
-    kubernetes.io/description: "Druid brokers"
+    druidOpResourceHash: nQv/LmxctTSRsI5dtBe3jvN5WM8=
+    kubernetes.io/cluster-scoped-annotation: "cluster"
+    kubernetes.io/node-scoped-annotation: "broker"
+    kubernetes.io/override-annotation: "node-scoped-annotation"
 spec:
   replicas: 2
   selector:

--- a/controllers/druid/testdata/broker-deployment.yaml
+++ b/controllers/druid/testdata/broker-deployment.yaml
@@ -9,7 +9,8 @@ metadata:
     nodeSpecUniqueStr: druid-druid-test-brokers
     component: broker
   annotations:
-    druidOpResourceHash: DYdfEwwDlLKgjTSZeuJb5nloe/w=
+    druidOpResourceHash: 3UqXvm9M4F36B6t2qb8/tz8zfCg=
+    kubernetes.io/description: "Druid brokers"
 spec:
   replicas: 2
   selector:

--- a/controllers/druid/testdata/broker-statefulset.yaml
+++ b/controllers/druid/testdata/broker-statefulset.yaml
@@ -9,7 +9,8 @@ metadata:
     nodeSpecUniqueStr: druid-druid-test-brokers
     component: broker
   annotations:
-    druidOpResourceHash: lTyDduvMnbQ7O2Glf57R9c5bFtA=
+    druidOpResourceHash: QypWEOM0LWkV0kTDE5yIQZylRKo=
+    kubernetes.io/description: "Druid brokers"
 spec:
   podManagementPolicy: Parallel
   replicas: 2

--- a/controllers/druid/testdata/broker-statefulset.yaml
+++ b/controllers/druid/testdata/broker-statefulset.yaml
@@ -9,8 +9,10 @@ metadata:
     nodeSpecUniqueStr: druid-druid-test-brokers
     component: broker
   annotations:
-    druidOpResourceHash: QypWEOM0LWkV0kTDE5yIQZylRKo=
-    kubernetes.io/description: "Druid brokers"
+    druidOpResourceHash: LXsKmbxQkX+94LkevlKDy4wemRQ=
+    kubernetes.io/cluster-scoped-annotation: "cluster"
+    kubernetes.io/node-scoped-annotation: "broker"
+    kubernetes.io/override-annotation: "node-scoped-annotation"
 spec:
   podManagementPolicy: Parallel
   replicas: 2

--- a/controllers/druid/testdata/druid-test-cr.yaml
+++ b/controllers/druid/testdata/druid-test-cr.yaml
@@ -109,6 +109,8 @@ spec:
   nodes:
     brokers:
       nodeType: "broker"
+      replicationControllerAnnotations:
+        kubernetes.io/description: "Druid brokers"
       services:
         - spec:
             type: ClusterIP

--- a/controllers/druid/testdata/druid-test-cr.yaml
+++ b/controllers/druid/testdata/druid-test-cr.yaml
@@ -7,6 +7,9 @@ spec:
   image: himanshu01/druid:druid-0.12.0-1
   defaultProbes: true
   priorityClassName: high-priority
+  replicationControllerAnnotations:
+    kubernetes.io/cluster-scoped-annotation: "cluster"
+    kubernetes.io/override-annotation: "cluster-scoped-annotation"
   podAnnotations:
     key1: value1
     key2: value2
@@ -110,7 +113,8 @@ spec:
     brokers:
       nodeType: "broker"
       replicationControllerAnnotations:
-        kubernetes.io/description: "Druid brokers"
+        kubernetes.io/node-scoped-annotation: "broker"
+        kubernetes.io/override-annotation: "node-scoped-annotation"
       services:
         - spec:
             type: ClusterIP

--- a/controllers/druid/testdata/druid-test-cr.yaml
+++ b/controllers/druid/testdata/druid-test-cr.yaml
@@ -7,7 +7,7 @@ spec:
   image: himanshu01/druid:druid-0.12.0-1
   defaultProbes: true
   priorityClassName: high-priority
-  replicationControllerAnnotations:
+  workloadAnnotations:
     kubernetes.io/cluster-scoped-annotation: "cluster"
     kubernetes.io/override-annotation: "cluster-scoped-annotation"
   podAnnotations:
@@ -112,7 +112,7 @@ spec:
   nodes:
     brokers:
       nodeType: "broker"
-      replicationControllerAnnotations:
+      workloadAnnotations:
         kubernetes.io/node-scoped-annotation: "broker"
         kubernetes.io/override-annotation: "node-scoped-annotation"
       services:

--- a/docs/api_specifications/druid.md
+++ b/docs/api_specifications/druid.md
@@ -609,6 +609,19 @@ map[string]string
 </tr>
 <tr>
 <td>
+<code>replicationControllerAnnotations</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.
+if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec ReplicationControllerAnnotations will take precedence.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>podManagementPolicy</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podmanagementpolicytype-v1-apps">
@@ -2311,6 +2324,19 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>PodAnnotations Custom annotations to be populated in <code>Druid</code> pods.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicationControllerAnnotations</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.
+if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec ReplicationControllerAnnotations will take precedence.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api_specifications/druid.md
+++ b/docs/api_specifications/druid.md
@@ -609,15 +609,15 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>replicationControllerAnnotations</code><br>
+<code>workloadAnnotations</code><br>
 <em>
 map[string]string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.
-if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec ReplicationControllerAnnotations will take precedence.</p>
+<p>WorkloadAnnotations annotations to be populated in StatefulSet or Deployment spec.
+if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec WorkloadAnnotations will take precedence.</p>
 </td>
 </tr>
 <tr>
@@ -1806,14 +1806,14 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>replicationControllerAnnotations</code><br>
+<code>workloadAnnotations</code><br>
 <em>
 map[string]string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.</p>
+<p>WorkloadAnnotations annotations to be populated in StatefulSet or Deployment spec.</p>
 </td>
 </tr>
 <tr>
@@ -2328,15 +2328,15 @@ map[string]string
 </tr>
 <tr>
 <td>
-<code>replicationControllerAnnotations</code><br>
+<code>workloadAnnotations</code><br>
 <em>
 map[string]string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.
-if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec ReplicationControllerAnnotations will take precedence.</p>
+<p>WorkloadAnnotations annotations to be populated in StatefulSet or Deployment spec.
+if the same key is specified at both the DruidNodeSpec level and DruidSpec level, the DruidNodeSpec WorkloadAnnotations will take precedence.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api_specifications/druid.md
+++ b/docs/api_specifications/druid.md
@@ -173,6 +173,56 @@ Kubernetes core/v1.ResourceRequirements
 </table>
 </div>
 </div>
+<h3 id="druid.apache.org/v1alpha1.Auth">Auth
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#druid.apache.org/v1alpha1.DruidIngestionSpec">DruidIngestionSpec</a>)
+</p>
+<div class="md-typeset__scrollwrap">
+<div class="md-typeset__table">
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.AuthType">
+AuthType
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretRef</code><br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretreference-v1-core">
+Kubernetes core/v1.SecretReference
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<h3 id="druid.apache.org/v1alpha1.AuthType">AuthType
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#druid.apache.org/v1alpha1.Auth">Auth</a>)
+</p>
 <h3 id="druid.apache.org/v1alpha1.DeepStorageSpec">DeepStorageSpec
 </h3>
 <p>
@@ -988,6 +1038,277 @@ Important: Run &ldquo;make&rdquo; to regenerate code after modifying this file</
 </table>
 </div>
 </div>
+<h3 id="druid.apache.org/v1alpha1.DruidIngestion">DruidIngestion
+</h3>
+<p>Ingestion is the Schema for the Ingestion API</p>
+<div class="md-typeset__scrollwrap">
+<div class="md-typeset__table">
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code><br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.DruidIngestionSpec">
+DruidIngestionSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>druidCluster</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingestion</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.IngestionSpec">
+IngestionSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>auth</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.Auth">
+Auth
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.DruidIngestionStatus">
+DruidIngestionStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<h3 id="druid.apache.org/v1alpha1.DruidIngestionMethod">DruidIngestionMethod
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#druid.apache.org/v1alpha1.IngestionSpec">IngestionSpec</a>)
+</p>
+<h3 id="druid.apache.org/v1alpha1.DruidIngestionSpec">DruidIngestionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#druid.apache.org/v1alpha1.DruidIngestion">DruidIngestion</a>)
+</p>
+<div class="md-typeset__scrollwrap">
+<div class="md-typeset__table">
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>druidCluster</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingestion</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.IngestionSpec">
+IngestionSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>auth</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.Auth">
+Auth
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<h3 id="druid.apache.org/v1alpha1.DruidIngestionStatus">DruidIngestionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#druid.apache.org/v1alpha1.DruidIngestion">DruidIngestion</a>)
+</p>
+<div class="md-typeset__scrollwrap">
+<div class="md-typeset__table">
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>taskId</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>type</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code><br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>lastUpdateTime</code><br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>currentIngestionSpec.json</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 <h3 id="druid.apache.org/v1alpha1.DruidNodeConditionType">DruidNodeConditionType
 (<code>string</code> alias)</h3>
 <p>
@@ -1468,6 +1789,18 @@ map[string]string
 <td>
 <em>(Optional)</em>
 <p>IngressAnnotations <code>Ingress</code> annotations to be populated in ingress spec.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicationControllerAnnotations</code><br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplicationControllerAnnotations annotations to be populated in StatefulSet or Deployment spec.</p>
 </td>
 </tr>
 <tr>
@@ -2265,6 +2598,52 @@ string
 <td>
 <em>(Optional)</em>
 <p>CoreSite Contents of <code>core-site.xml</code>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<h3 id="druid.apache.org/v1alpha1.IngestionSpec">IngestionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#druid.apache.org/v1alpha1.DruidIngestionSpec">DruidIngestionSpec</a>)
+</p>
+<div class="md-typeset__scrollwrap">
+<div class="md-typeset__table">
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code><br>
+<em>
+<a href="#druid.apache.org/v1alpha1.DruidIngestionMethod">
+DruidIngestionMethod
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+</table>
 </td>
 </tr>
 </tbody>

--- a/e2e/configs/druid-cr.yaml
+++ b/e2e/configs/druid-cr.yaml
@@ -129,6 +129,8 @@ spec:
       # imagePullSecrets:
       # - name: tutu
       priorityClassName: system-cluster-critical 
+      replicationControllerAnnotations:
+        kubernetes.io/description: "Druid brokers"
       druid.port: 8088
       services:
         - spec:

--- a/e2e/configs/druid-cr.yaml
+++ b/e2e/configs/druid-cr.yaml
@@ -13,7 +13,7 @@ spec:
     release: alpha
   podAnnotations:
     dummy: k8s_extn_needs_atleast_one_annotation
-  replicationControllerAnnotations:
+  workloadAnnotations:
     kubernetes.io/cluster-scoped-annotation: "cluster"
   readinessProbe:
     httpGet:
@@ -131,7 +131,7 @@ spec:
       # imagePullSecrets:
       # - name: tutu
       priorityClassName: system-cluster-critical 
-      replicationControllerAnnotations:
+      workloadAnnotations:
         kubernetes.io/node-scoped-annotation: "broker"
       druid.port: 8088
       services:

--- a/e2e/configs/druid-cr.yaml
+++ b/e2e/configs/druid-cr.yaml
@@ -13,6 +13,8 @@ spec:
     release: alpha
   podAnnotations:
     dummy: k8s_extn_needs_atleast_one_annotation
+  replicationControllerAnnotations:
+    kubernetes.io/cluster-scoped-annotation: "cluster"
   readinessProbe:
     httpGet:
       path: /status/health
@@ -130,7 +132,7 @@ spec:
       # - name: tutu
       priorityClassName: system-cluster-critical 
       replicationControllerAnnotations:
-        kubernetes.io/description: "Druid brokers"
+        kubernetes.io/node-scoped-annotation: "broker"
       druid.port: 8088
       services:
         - spec:


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes https://github.com/datainfrahq/druid-operator/issues/142

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description
Adding a `ReplicationControllerAnnotations` field to the DruidNodeSpec schema. This allows users to specify annotations to be applied to the StatefulSet / Deployment object. 

I'm not 100% sure of the naming - what do you think? I didn't want to call it `StatefulSetAnnotations` since the user can opt for a deployment instead.

Also regenerated the API docs, which led to a huge diff as it appears they weren't regenerated after https://github.com/datainfrahq/druid-operator/pull/53 (hence the huge diff)

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added documentation for new or modified features or behaviors.

I haven't tested this on a real kube cluster, but all of the e2e tests run. Is that sufficient for an overall minor/straightforward change?
