### PR TITLE
fix(eks deployment): Add expected volumeClaim to eks.yaml 

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,8 +59,8 @@ kubectl apply -f examples/tiny-cluster-zk.yaml
 kubectl apply -f examples/tiny-cluster.yaml
 ```
 
-`NOTE:` that above tiny-cluster only works on a single node kubernetes cluster(e.g. typical k8s cluster setup for dev 
-using kind or minikube) as it uses local disk as "deep storage".
+`NOTE:` the above tiny-cluster only works on a single node kubernetes cluster (e.g. typical k8s cluster setup for dev 
+using kind or minikube) as it uses local disk as "deep storage". Other example specs in the `examples/` directory use distributed "deep storage" and therefore expect to be deployed into a k8s cluster with s3-compatible storage. To bootstrap your k8s cluster with s3-compatible storage, you can run `make helm-minio-install`. See the [Makefile](../Makefile) for more details.
 
 
 ## Debugging Problems

--- a/examples/aws/eks.yaml
+++ b/examples/aws/eks.yaml
@@ -248,6 +248,18 @@ spec:
         "[MEM] Response Rate: Success"],
         "type" : "count" }
     }
+  volumeMounts:
+    - mountPath: /druid/data
+      name: data-volume
+    - mountPath: /druid/deepstorage
+      name: deepstorage-volume
+  volumes:
+    - name: data-volume
+      emptyDir: {}
+    - name: deepstorage-volume
+      hostPath:
+        path: /tmp/druid/deepstorage
+        type: DirectoryOrCreate
   env:
     - name: POD_NAME
       valueFrom:
@@ -266,7 +278,7 @@ spec:
       # Optionally specify for broker nodes
       # imagePullSecrets:
       # - name: tutu
-      priorityClassName: system-cluster-critical 
+      priorityClassName: system-cluster-critical
       druid.port: 8088
       services:
         - spec:
@@ -275,15 +287,15 @@ spec:
       nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/broker"
       replicas: 1
       volumeClaimTemplates:
-       - metadata:
-           name: data-volume
-         spec:
-           accessModes:
-           - ReadWriteOnce
-           resources:
-             requests:
-               storage: 2Gi
-           storageClassName: gp2
+        - metadata:
+            name: data-volume
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 2Gi
+            storageClassName: gp2
       runtime.properties: |
         druid.service=druid/broker
         # HTTP server threads
@@ -340,15 +352,15 @@ spec:
         -Xmx512m
         -Xms512m
       volumeClaimTemplates:
-      - metadata:
-          name: data-volume
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 2Gi
-          storageClassName: gp2
+        - metadata:
+            name: data-volume
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 2Gi
+            storageClassName: gp2
 
     routers:
       nodeType: "router"
@@ -399,21 +411,21 @@ kind: Role
 metadata:
   name: druid-cluster
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - configmaps
-  verbs:
-  - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+    verbs:
+      - "*"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: druid-cluster
 subjects:
-- kind: ServiceAccount
-  name: default
+  - kind: ServiceAccount
+    name: default
 roleRef:
   kind: Role
   name: druid-cluster


### PR DESCRIPTION
Fixes #147 .

### Description

`examples/aws/eks.yaml` was missing volumeClaim and volume causing the deployment to fail. I added them. Additionally, I improved the "getting_started" documentation, pointing out the minio dependency for most of the examples and referencing the makefile for bootstrapping minio.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `examples/aws/eks.yaml`
 * `docs/getting_started.md`