### PR TITLE
feat(chart): option to not create clusterRoles;

### DIFF
--- a/chart/templates/rbac_manager.yaml
+++ b/chart/templates/rbac_manager.yaml
@@ -182,6 +182,7 @@ rules:
 {{- end }}
 
 ---
+{{- if .Values.global.createClusterRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -357,6 +358,7 @@ rules:
     - get
     - list
     - watch
+{{- end }}
 
 {{- $operatorName := (include "druid-operator.fullname" .) -}}
 {{- if and ($env.WATCH_NAMESPACE) (ne $env.WATCH_NAMESPACE "default") }}
@@ -382,6 +384,7 @@ roleRef:
 {{- end }}
 {{- end }}
 ---
+{{- if .Values.global.createClusterRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -399,3 +402,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "druid-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/templates/rbac_metrics.yaml
+++ b/chart/templates/rbac_metrics.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.global.createClusterRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -13,3 +14,4 @@ rules:
       - /metrics
     verbs:
       - get
+{{- end }}

--- a/chart/templates/rbac_proxy.yaml
+++ b/chart/templates/rbac_proxy.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.global.createClusterRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -39,3 +40,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "druid-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  createClusterRole: true
+
 env:
   DENY_LIST: "default,kube-system" # Comma-separated list of namespaces to ignore
   RECONCILE_WAIT: "10s" # Reconciliation delay
@@ -21,7 +24,6 @@ kube_rbac_proxy:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
     pullPolicy: IfNotPresent
     tag: "v0.13.1"
-
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Related to #170 and #162 

When destroying and re-creating the operator (for example when moving to another namespace) we want to keep CRDs and ClusterRoles around. This PR adds an option `createClusterRoles` to the helm chart which can be used to re-create the operator without re-creating the ClusterRoles, which would currently fail.
The default value is true and thus default behavior of the chart will not change.

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.


