### PR TITLE
Fix typo in probe definition

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -213,7 +213,7 @@ All the probes definitions are documented bellow:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 5
-  startupProbe:
+  startUpProbe:
     failureThreshold: 20
     httpGet:
       path: /druid/historical/v1/readiness


### PR DESCRIPTION
### Description

The documentation for the "Default Yet Configurable" `startUpProbe` contains a small typo where the `u` in `startUp` is not capitalized. This can cause some confusion when trying to incorporate this example config into a Druid configuration.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `docs/features.md`
