### PR TITLE
Fix node spec podLabels bug

### DIFF
--- a/controllers/druid/handler.go
+++ b/controllers/druid/handler.go
@@ -1268,17 +1268,16 @@ func makeLabelsForDruid(druid *v1alpha1.Druid) map[string]string {
 }
 
 // makeLabelsForDruid returns the labels for selecting the resources
-// belonging to the given druid CR name.
+// belonging to the given druid CR name. adds labels from both node &
+// cluster specs. node spec labels will take precedence over clusters labels
 func makeLabelsForNodeSpec(nodeSpec *v1alpha1.DruidNodeSpec, m *v1alpha1.Druid, clusterName, nodeSpecUniqueStr string) map[string]string {
 	var labels = map[string]string{}
 
-	// if both labels are present at both cluster and node spec
-	// labels should be merged.
-	if nodeSpec.PodLabels != nil && m.Spec.PodLabels != nil {
-		labels = nodeSpec.PodLabels
+	for k, v := range m.Spec.PodLabels {
+		labels[k] = v
 	}
 
-	for k, v := range m.Spec.PodLabels {
+	for k, v := range nodeSpec.PodLabels {
 		labels[k] = v
 	}
 


### PR DESCRIPTION


Fixes #183 



### Description

The operator does not add node spec's podLabels to the statefulsets unless a user also defines podLabels for the cluster spec.

This change will always add both cluster and node spec podLabels as long as they are defined. If same labels are defined for both cluster spec and pod spec then it'll prefer node spec values over cluster spec.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>


