### PR TITLE
Ability to use secrets as environment variables

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.7
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -76,6 +76,13 @@ spec:
             - name: {{ $key }}
               value: {{ tpl $value $ | quote }}
             {{- end }}
+            {{- range $entry := .Values.envFromSecrets }}
+            - name: "{{ $entry.name | quote }}"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $entry.secretKeyRefName | quote }}
+                  key: {{ $entry.secretKeyRefKey  | quote }}
+            {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,6 +11,8 @@ env:
   WATCH_NAMESPACE: "" # Namespace to watch or empty string to watch all namespaces, To watch multiple namespaces add , into string. Ex: WATCH_NAMESPACE: "ns1,ns2,ns3"
   #MAX_CONCURRENT_RECONCILES:: ""  # MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
 
+envFromSecrets: {}
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

### Description

In order to improve the security posture of druid installations using helm chart, I propose this change where environment variables can be set using kubernetes secrets.
This would be useful, for example, when configuring a [Postgres extension](https://druid.apache.org/docs/latest/development/extensions-core/postgresql/) where one needs to provide credentials.

Example of usage:

```
envFromSecrets:
  - name: "druid.metadata.storage.connector.user"
    secretKeyRefKey: "databaseSecrets"
    secretKeyRefName: "username"
  - name: "druid.metadata.storage.connector.password"
    secretKeyRefKey: "databaseSecrets"
    secretKeyRefName: "password"
```

I'm opening as a draft to get initial feedback. If you agree with the proposal I'll polish the code and update the docs.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>
