### PR TITLE
Stop using cluster domain suffix for DruidIngestion

### DIFF
--- a/pkg/druidapi/druidapi.go
+++ b/pkg/druidapi/druidapi.go
@@ -129,7 +129,7 @@ func GetRouterSvcUrl(namespace, druidClusterName string, c client.Client) (strin
 		return "", errors.New("router svc discovery fail")
 	}
 
-	newName := "http://" + svcName + "." + namespace + ".svc.cluster.local:" + DruidRouterPort
+	newName := "http://" + svcName + "." + namespace + ":" + DruidRouterPort
 
 	return newName, nil
 }


### PR DESCRIPTION
Fixes #213.

### Description

GetRouterSvcUrl in druidapi.go hard-codes cluster.local as a domain suffix.  This breaks DruidIngestion for Kubernetes clusters that use a custom cluster name.  But, given that GetRouterSvcUrl will be called within the same namespace as the router service, there is no need to use a fully qualified name.  By using the relative name, we avoid needing to look up what domain suffix to use.

This patch removes `svc.cluster.local` from the URL of the Druid router service returned by GetRouterSvcUrl.

If this patch is rejected for not using the fqdn, then we need to dynamically look up the current cluster domain rather than assume it is `cluster.local`.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `pkg/druidapi/druidapi.go`
