### PR TITLE
feat: Add support for custom username and password keys in auth.

### DIFF
--- a/chart/crds/druid.apache.org_druidingestions.yaml
+++ b/chart/crds/druid.apache.org_druidingestions.yaml
@@ -47,6 +47,10 @@ spec:
             properties:
               auth:
                 properties:
+                  passwordKey:
+                    description: PasswordKey specifies the key within the Kubernetes
+                      secret that contains the password for authentication.
+                    type: string
                   secretRef:
                     description: |-
                       SecretReference represents a Secret Reference. It has enough information to retrieve secret
@@ -63,6 +67,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type:
+                    type: string
+                  usernameKey:
+                    description: UsernameKey specifies the key within the Kubernetes
+                      secret that contains the username for authentication.
                     type: string
                 required:
                 - secretRef

--- a/chart/crds/druid.apache.org_druids.yaml
+++ b/chart/crds/druid.apache.org_druids.yaml
@@ -1267,6 +1267,10 @@ spec:
                 type: object
               auth:
                 properties:
+                  passwordKey:
+                    description: PasswordKey specifies the key within the Kubernetes
+                      secret that contains the password for authentication.
+                    type: string
                   secretRef:
                     description: |-
                       SecretReference represents a Secret Reference. It has enough information to retrieve secret
@@ -1283,6 +1287,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type:
+                    type: string
+                  usernameKey:
+                    description: UsernameKey specifies the key within the Kubernetes
+                      secret that contains the username for authentication.
                     type: string
                 required:
                 - secretRef

--- a/config/crd/bases/druid.apache.org_druidingestions.yaml
+++ b/config/crd/bases/druid.apache.org_druidingestions.yaml
@@ -47,6 +47,10 @@ spec:
             properties:
               auth:
                 properties:
+                  passwordKey:
+                    description: PasswordKey specifies the key within the Kubernetes
+                      secret that contains the password for authentication.
+                    type: string
                   secretRef:
                     description: |-
                       SecretReference represents a Secret Reference. It has enough information to retrieve secret
@@ -63,6 +67,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type:
+                    type: string
+                  usernameKey:
+                    description: UsernameKey specifies the key within the Kubernetes
+                      secret that contains the username for authentication.
                     type: string
                 required:
                 - secretRef

--- a/config/crd/bases/druid.apache.org_druids.yaml
+++ b/config/crd/bases/druid.apache.org_druids.yaml
@@ -1267,6 +1267,10 @@ spec:
                 type: object
               auth:
                 properties:
+                  passwordKey:
+                    description: PasswordKey specifies the key within the Kubernetes
+                      secret that contains the password for authentication.
+                    type: string
                   secretRef:
                     description: |-
                       SecretReference represents a Secret Reference. It has enough information to retrieve secret
@@ -1283,6 +1287,10 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   type:
+                    type: string
+                  usernameKey:
+                    description: UsernameKey specifies the key within the Kubernetes
+                      secret that contains the username for authentication.
                     type: string
                 required:
                 - secretRef

--- a/docs/api_specifications/druid.md
+++ b/docs/api_specifications/druid.md
@@ -173,56 +173,6 @@ Kubernetes core/v1.ResourceRequirements
 </table>
 </div>
 </div>
-<h3 id="druid.apache.org/v1alpha1.Auth">Auth
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#druid.apache.org/v1alpha1.DruidIngestionSpec">DruidIngestionSpec</a>)
-</p>
-<div class="md-typeset__scrollwrap">
-<div class="md-typeset__table">
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code><br>
-<em>
-<a href="#druid.apache.org/v1alpha1.AuthType">
-AuthType
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretRef</code><br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#secretreference-v1-core">
-Kubernetes core/v1.SecretReference
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<h3 id="druid.apache.org/v1alpha1.AuthType">AuthType
-(<code>string</code> alias)</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#druid.apache.org/v1alpha1.Auth">Auth</a>)
-</p>
 <h3 id="druid.apache.org/v1alpha1.DeepStorageSpec">DeepStorageSpec
 </h3>
 <p>
@@ -909,6 +859,29 @@ string
 </tr>
 <tr>
 <td>
+<code>dynamicConfig</code><br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Dynamic Configurations for Druid. Applied through the dynamic configuration API.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auth</code><br>
+<em>
+github.com/datainfrahq/druid-operator/pkg/druidapi.Auth
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
 <code>dnsPolicy</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#dnspolicy-v1-core">
@@ -1156,9 +1129,7 @@ IngestionSpec
 <td>
 <code>auth</code><br>
 <em>
-<a href="#druid.apache.org/v1alpha1.Auth">
-Auth
-</a>
+github.com/datainfrahq/druid-operator/pkg/druidapi.Auth
 </em>
 </td>
 <td>
@@ -1243,9 +1214,7 @@ IngestionSpec
 <td>
 <code>auth</code><br>
 <em>
-<a href="#druid.apache.org/v1alpha1.Auth">
-Auth
-</a>
+github.com/datainfrahq/druid-operator/pkg/druidapi.Auth
 </em>
 </td>
 <td>
@@ -1341,6 +1310,18 @@ Kubernetes meta/v1.Time
 <code>currentIngestionSpec.json</code><br>
 <em>
 string
+</em>
+</td>
+<td>
+<p>CurrentIngestionSpec is a string instead of RawExtension to maintain compatibility with existing
+IngestionSpecs that are stored as JSON strings.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rules</code><br>
+<em>
+[]k8s.io/apimachinery/pkg/runtime.RawExtension
 </em>
 </td>
 <td>
@@ -1968,6 +1949,30 @@ Kubernetes autoscaling/v2.HorizontalPodAutoscalerSpec
 <td>
 <em>(Optional)</em>
 <p>Operator deploys the sidecar container based on these properties.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code><br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName Kubernetes native <code>serviceAccountName</code> specification.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>dynamicConfig</code><br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Dynamic Configurations for Druid. Applied through the dynamic configuration API.</p>
 </td>
 </tr>
 <tr>
@@ -2684,6 +2689,29 @@ string
 </tr>
 <tr>
 <td>
+<code>dynamicConfig</code><br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Dynamic Configurations for Druid. Applied through the dynamic configuration API.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auth</code><br>
+<em>
+github.com/datainfrahq/druid-operator/pkg/druidapi.Auth
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
 <code>dnsPolicy</code><br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#dnspolicy-v1-core">
@@ -2750,10 +2778,50 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
+<p>Spec should be passed in as a JSON string.
+Note: This field is planned for deprecation in favor of nativeSpec.</p>
 <br/>
 <br/>
 <table>
 </table>
+</td>
+</tr>
+<tr>
+<td>
+<code>nativeSpec</code><br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>nativeSpec allows the ingestion specification to be defined in a native Kubernetes format.
+This is particularly useful for environment-specific configurations and will eventually
+replace the JSON-based Spec field.
+Note: Spec will be ignored if nativeSpec is provided.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>compaction</code><br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>rules</code><br>
+<em>
+[]k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
 </td>
 </tr>
 </tbody>

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/pkg/druidapi/druidapi_test.go
+++ b/pkg/druidapi/druidapi_test.go
@@ -1,8 +1,118 @@
 package druidapi
 
 import (
+	"context"
+	internalhttp "github.com/datainfrahq/druid-operator/pkg/http"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
+
+func TestGetAuthCreds(t *testing.T) {
+	tests := []struct {
+		name      string
+		auth      Auth
+		expected  internalhttp.BasicAuth
+		expectErr bool
+	}{
+		{
+			name: "default keys present",
+			auth: Auth{
+				Type:      BasicAuth,
+				SecretRef: v1.SecretReference{Name: "test-default", Namespace: "test"},
+			},
+			expected:  internalhttp.BasicAuth{UserName: "test-user", Password: "test-password"},
+			expectErr: false,
+		},
+		{
+			name: "custom keys present",
+			auth: Auth{
+				Type:        BasicAuth,
+				SecretRef:   v1.SecretReference{Name: "test", Namespace: "default"},
+				UsernameKey: "usr",
+				PasswordKey: "pwd",
+			},
+			expected:  internalhttp.BasicAuth{UserName: "admin", Password: "admin"},
+			expectErr: false,
+		},
+		{
+			name: "custom user key is  missing",
+			auth: Auth{
+				Type:        BasicAuth,
+				SecretRef:   v1.SecretReference{Name: "test", Namespace: "default"},
+				UsernameKey: "nope",
+				PasswordKey: "pwd",
+			},
+			expected:  internalhttp.BasicAuth{},
+			expectErr: true,
+		},
+		{
+			name: "custom user key with default password key",
+			auth: Auth{
+				Type:        BasicAuth,
+				SecretRef:   v1.SecretReference{Name: "test", Namespace: "default"},
+				UsernameKey: "usr",
+			},
+			expected:  internalhttp.BasicAuth{UserName: "admin", Password: "also-admin"},
+			expectErr: false,
+		},
+		{
+			name: "custom password key is missing",
+			auth: Auth{
+				Type:        BasicAuth,
+				SecretRef:   v1.SecretReference{Name: "test", Namespace: "default"},
+				UsernameKey: "usr",
+				PasswordKey: "nope",
+			},
+			expected:  internalhttp.BasicAuth{},
+			expectErr: true,
+		},
+		{
+			name:      "empty auth struct returns no creds",
+			auth:      Auth{},
+			expected:  internalhttp.BasicAuth{},
+			expectErr: false,
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithObjects(&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-default",
+				Namespace: "test",
+			},
+			Data: map[string][]byte{
+				OperatorUserName: []byte("test-user"),
+				OperatorPassword: []byte("test-password"),
+			},
+		}).
+		WithObjects(&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Data: map[string][]byte{
+				"usr":            []byte("admin"),
+				"pwd":            []byte("admin"),
+				OperatorPassword: []byte("also-admin"),
+			},
+		}).Build()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := GetAuthCreds(context.TODO(), client, tt.auth)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
 
 func TestMakePath(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### Description

I have druid cluster managed with this operator and encountered limitation when trying to use existing secrets that have different key names for authentication credentials. The operator was hardcoded to look for specific keys `OperatorUserName` and `OperatorPassword` in kubernetes secrets.

<!-- Describe the possible solutions and chosen one with the rationale. -->

The possible solutions were:
1. Create new secrets with expected key names (e.g. external-secret operator) - but this creates duplication and maintenance overhead
2. Modify operator to accept custom key names - chosen solution as it provides flexibility without breaking existing functionality

This PR adds optional `usernameKey` and `passwordKey` fields to Auth configuration.

<hr>

This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [x] been tested for backward compatibility on a real K8S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `pkg/druidapi/druidapi.go` - Updated Auth struct and GetAuthCreds function to support custom keys
 * `pkg/druidapi/druidapi_test.go` - Added comprehensive tests for new functionality
 