### PR TITLE
Make local k8s setup work for mmless configuration

### DIFF
--- a/examples/tiny-cluster-mmless.yaml
+++ b/examples/tiny-cluster-mmless.yaml
@@ -44,7 +44,7 @@ spec:
   services:
     - spec:
         type: ClusterIP
-#        clusterIP: None
+        clusterIP: None
   commonConfigMountPath: "/opt/druid/conf/druid/cluster/_common"
   jvm.options: |-
     -server

--- a/examples/tiny-cluster-mmless.yaml
+++ b/examples/tiny-cluster-mmless.yaml
@@ -44,10 +44,11 @@ spec:
   services:
     - spec:
         type: ClusterIP
-        clusterIP: None
+#        clusterIP: None
   commonConfigMountPath: "/opt/druid/conf/druid/cluster/_common"
   jvm.options: |-
     -server
+    -Djava.net.preferIPv4Stack=true
     -XX:MaxDirectMemorySize=10240g
     -Duser.timezone=UTC
     -Dfile.encoding=UTF-8
@@ -136,7 +137,7 @@ spec:
             type: ClusterIP
             clusterIP: None
       nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/broker"
-      replicas: s
+      replicas: 1
       runtime.properties: |
         druid.service=druid/broker
         # HTTP server threads
@@ -145,6 +146,7 @@ spec:
         # Processing threads and buffers
         druid.processing.buffer.sizeBytes=25000000
         druid.sql.enable=true
+        druid.host=druid-tiny-cluster-brokers
       extra.jvm.options: |-
         -Xmx512m
         -Xms512m
@@ -173,6 +175,7 @@ spec:
         druid.indexer.runner.namespace: druid
         druid.indexer.runner.type: k8s
         druid.indexer.task.encapsulatedTask: true
+        druid.host=druid-tiny-cluster-coordinators
       extra.jvm.options: |-
         -Xmx800m
         -Xms800m
@@ -239,6 +242,7 @@ spec:
         # Segment storage
         druid.segmentCache.locations=[{"path":"/druid/data/segments","maxSize":1000000000}]
         druid.server.maxSize=1000000000
+        druid.host=druid-tiny-cluster-hot
       extra.jvm.options: |-
         -Xmx512m
         -Xms512m
@@ -305,6 +309,7 @@ spec:
         # Segment storage
         druid.segmentCache.locations=[{"path":"/druid/data/segments","maxSize":2000000000}]
         druid.server.maxSize=2000000000
+        druid.host=druid-tiny-cluster-cold
       extra.jvm.options: |-
         -Xmx512m
         -Xms512m
@@ -331,6 +336,7 @@ spec:
         druid.router.coordinatorServiceName=druid/coordinator
         # Management proxy to coordinator / overlord: required for unified web console.
         druid.router.managementProxy.enabled=true
+        druid.host=druid-tiny-cluster-routers
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Gets the pods to contact to each other locally. Without these changes, the pods were using the entire pod name to be able to connect with each other.

However, in k8s, the dns records for pod names doesn't exist, however they exist for specific nodes. Kindly see the example

### DNS record search by pod name
```
bash-5.1# nslookup druid-tiny-cluster-coordinators-56d5865467-2hmqc
Server:         10.96.0.10
Address:        10.96.0.10:53

** server can't find druid-tiny-cluster-coordinators-56d5865467-2hmqc.cluster.local: NXDOMAIN

** server can't find druid-tiny-cluster-coordinators-56d5865467-2hmqc.cluster.local: NXDOMAIN

** server can't find druid-tiny-cluster-coordinators-56d5865467-2hmqc.druid.svc.cluster.local: NXDOMAIN

** server can't find druid-tiny-cluster-coordinators-56d5865467-2hmqc.svc.cluster.local: NXDOMAIN

** server can't find druid-tiny-cluster-coordinators-56d5865467-2hmqc.svc.cluster.local: NXDOMAIN

** server can't find druid-tiny-cluster-coordinators-56d5865467-2hmqc.druid.svc.cluster.local: NXDOMAIN
```

### DNS record by nodename.
```
bash-5.1# nslookup druid-tiny-cluster-coordinators                 
Server:         10.96.0.10
Address:        10.96.0.10:53

** server can't find druid-tiny-cluster-coordinators.cluster.local: NXDOMAIN

Name:   druid-tiny-cluster-coordinators.druid.svc.cluster.local
Address: 10.244.0.104

** server can't find druid-tiny-cluster-coordinators.cluster.local: NXDOMAIN

** server can't find druid-tiny-cluster-coordinators.svc.cluster.local: NXDOMAIN

** server can't find druid-tiny-cluster-coordinators.svc.cluster.local: NXDOMAIN

```



This PR has:
- [x] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `tiny-cluster-mmless.yaml`
