### PR TITLE
docs: Add comprehensive example for configuration via standard Druid environment variables (Secret Injection)

### DIFF
--- a/examples/tiny-cluster-hpa.yaml
+++ b/examples/tiny-cluster-hpa.yaml
@@ -60,10 +60,8 @@ spec:
 
     # Metadata Store
     druid.metadata.storage.type=derby
-    druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
-    druid.metadata.storage.connector.host=localhost
-    druid.metadata.storage.connector.port=1527
     druid.metadata.storage.connector.createTables=true
+    # Other settings are set via environment variables
 
     # Deep Storage
     druid.storage.type=local
@@ -96,6 +94,15 @@ spec:
         path: /tmp/druid/deepstorage
         type: DirectoryOrCreate
   env:
+    - name: druid_metadata_storage_type
+      value: derby
+    - name: druid_metadata_storage_connector_connectURI
+      value: jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
+    - name: druid_metadata_storage_connector_host
+      value: localhost
+    - name: druid_metadata_storage_connector_port
+      value: "1527"
+    # Other env vars
     - name: POD_NAME
       valueFrom:
         fieldRef:
@@ -186,7 +193,7 @@ spec:
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M
-          
+
     routers:
       nodeType: "router"
       druid.port: 8088
@@ -206,7 +213,7 @@ spec:
         druid.router.coordinatorServiceName=druid/coordinator
 
         # Management proxy to coordinator / overlord: required for unified web console.
-        druid.router.managementProxy.enabled=true       
+        druid.router.managementProxy.enabled=true
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M

--- a/examples/tiny-cluster.yaml
+++ b/examples/tiny-cluster.yaml
@@ -60,10 +60,8 @@ spec:
 
     # Metadata Store
     druid.metadata.storage.type=derby
-    druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
-    druid.metadata.storage.connector.host=localhost
-    druid.metadata.storage.connector.port=1527
     druid.metadata.storage.connector.createTables=true
+    # Other settings are set via environment variables
 
     # Deep Storage
     druid.storage.type=local
@@ -259,6 +257,14 @@ spec:
         path: /tmp/druid/deepstorage
         type: DirectoryOrCreate
   env:
+    - name: druid_metadata_storage_type
+      value: derby
+    - name: druid_metadata_storage_connector_connectURI
+      value: jdbc:derby://localhost:1527/druid/data/derbydb/metadata.db;create=true
+    - name: druid_metadata_storage_connector_host
+      value: localhost
+    - name: druid_metadata_storage_connector_port
+      value: "1527"
     - name: POD_NAME
       valueFrom:
         fieldRef:
@@ -280,15 +286,15 @@ spec:
       nodeConfigMountPath: "/opt/druid/conf/druid/cluster/query/broker"
       replicas: 1
       volumeClaimTemplates:
-       - metadata:
-           name: data-volume
-         spec:
-           accessModes:
-           - ReadWriteOnce
-           resources:
-             requests:
-               storage: 2Gi
-           storageClassName: standard
+        - metadata:
+            name: data-volume
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 2Gi
+            storageClassName: standard
       runtime.properties: |
         druid.service=druid/broker
         # HTTP server threads
@@ -344,7 +350,7 @@ spec:
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M
-          
+
     routers:
       nodeType: "router"
       druid.port: 8088
@@ -364,7 +370,7 @@ spec:
         druid.router.coordinatorServiceName=druid/coordinator
 
         # Management proxy to coordinator / overlord: required for unified web console.
-        druid.router.managementProxy.enabled=true       
+        druid.router.managementProxy.enabled=true
       extra.jvm.options: |-
         -Xmx512M
         -Xms512M


### PR DESCRIPTION
### Description

The current documentation for securing configuration (like metadata store connection strings) primarily uses the inline JSON format (`{"type": "environment", "variable": "VAR"}`) within `runtime.properties`.

This approach presents two main limitations:
1. **Scope Restriction:** The inline JSON substitution feature appears limited to specific password fields within Druid, leading to configuration failures when applied to other critical properties (like connection URIs).
2. **Redundancy:** It forces the user to manually configure both the environment variable in the Pod spec *and* the inline JSON substitution logic in the `.properties` files.

This PR introduces and documents the recommended alternative leveraging the default behavior of the official Druid Docker entrypoint: any environment variable prefixed with `druid_` is automatically converted into the corresponding Druid property (`druid_storage_type` becomes `druid.storage.type`).

This standardized approach offers superior security and flexibility by allowing operators to:
* Securely inject **any** sensitive or environment-specific configuration (like database credentials, deep storage keys, or full connection strings) directly from Kubernetes Secrets via `valueFrom`.
* Completely remove sensitive data from static configuration files (`runtime.properties`), adhering to secrets management best practices.

**Changes:**

1. Added a new section in `docs/examples.md`: **Configuration via Environment Variables (Recommended for sensitive data)**, detailing the use of `druid_` prefixed environment variables mapped from Kubernetes Secrets.
2. Updated `examples/tiny-cluster.yaml` and `examples/tiny-cluster-hpa.yaml` to demonstrate the new approach by moving metadata storage configuration from `runtime.properties` to environment variables.
3. Retained the original JSON-based password documentation for backward reference, but explicitly notes the new method for broader configuration management.