### PR TITLE
Remove privileged security context from example YAML files

### DIFF
--- a/e2e/configs/druid-cr.yaml
+++ b/e2e/configs/druid-cr.yaml
@@ -40,8 +40,6 @@ spec:
     fsGroup: 0
     runAsUser: 0
     runAsGroup: 0
-  containerSecurityContext:
-    privileged: true
   services:
     - spec:
         type: ClusterIP

--- a/e2e/configs/druid-mmless.yaml
+++ b/e2e/configs/druid-mmless.yaml
@@ -37,8 +37,6 @@ spec:
     fsGroup: 0
     runAsUser: 0
     runAsGroup: 0
-  containerSecurityContext:
-    privileged: true
   services:
     - spec:
         type: ClusterIP

--- a/examples/tiny-cluster-mmless.yaml
+++ b/examples/tiny-cluster-mmless.yaml
@@ -39,8 +39,6 @@ spec:
     fsGroup: 0
     runAsUser: 0
     runAsGroup: 0
-  containerSecurityContext:
-    privileged: true
   services:
     - spec:
         type: ClusterIP

--- a/tutorials/druid-on-kind/druid-mmless.yaml
+++ b/tutorials/druid-on-kind/druid-mmless.yaml
@@ -37,8 +37,6 @@ spec:
     fsGroup: 0
     runAsUser: 0
     runAsGroup: 0
-  containerSecurityContext:
-    privileged: true
   services:
     - spec:
         type: ClusterIP


### PR DESCRIPTION
Fixes #178

### Description

The example YAML files had `containerSecurityContext.privileged: true` set, which is a security risk and unnecessary for running Druid clusters. Running containers in privileged mode grants them full access to the host, which violates the principle of least privilege.

This PR removes the `privileged: true` setting from all affected example files while keeping the other security context settings (`fsGroup`, `runAsUser`, `runAsGroup`) intact.

---

##### Key changed/added files in this PR
* `e2e/configs/druid-cr.yaml`
* `e2e/configs/druid-mmless.yaml`
* `tutorials/druid-on-kind/druid-mmless.yaml`
* `examples/tiny-cluster-mmless.yaml`
