### PR TITLE
Allow securityContext configuration on kube-rbac-proxy container

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -66,10 +66,7 @@ spec:
               cpu: 5m
               memory: 64Mi
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.kube_rbac_proxy.securityContext | nindent 12 }}
         - args:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=127.0.0.1:8080

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,6 +24,11 @@ kube_rbac_proxy:
     repository: gcr.io/kubebuilder/kube-rbac-proxy
     pullPolicy: IfNotPresent
     tag: "v0.13.1"
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Fixes #238

## Description

The Helm chart had a hardcoded `securityContext` for the `kube-rbac-proxy` container, which prevented users from customizing security settings .

This PR makes the `securityContext` configurable via `values.yaml` while maintaining backward compatibility by preserving the existing defaults.

## Key changed/added files in this PR

- `chart/values.yaml` - Added `securityContext` field under `kube_rbac_proxy` with default values
- `chart/templates/deployment.yaml` - Replaced hardcoded securityContext with template reference

## Testing

- [x] `helm lint ./chart` passes with no errors
- [x] `helm template` renders correctly with default values
- [x] `helm template` renders correctly with custom securityContext overrides
- [x] Verified backward compatibility - existing deployments work without changes


## Usage

Users can now override the kube-rbac-proxy securityContext in their values:

```yaml
kube_rbac_proxy:
  securityContext:
    allowPrivilegeEscalation: false
    runAsNonRoot: true
    runAsUser: 1000
    readOnlyRootFilesystem: true
    capabilities:
      drop:
        - ALL
