### PR TITLE
fix: read router port from service spec instead of hardcoded value

### DIFF
--- a/pkg/druidapi/druidapi.go
+++ b/pkg/druidapi/druidapi.go
@@ -155,7 +155,13 @@ func GetRouterSvcUrl(namespace, druidClusterName string, c client.Client) (strin
 		return "", errors.New("router svc discovery fail")
 	}
 
-	newName := "http://" + svcName + "." + namespace + ":" + DruidRouterPort
+	// Get port from service spec, fallback to default DruidRouterPort
+	port := DruidRouterPort
+	if len(svcList.Items[0].Spec.Ports) > 0 {
+		port = fmt.Sprintf("%d", svcList.Items[0].Spec.Ports[0].Port)
+	}
+
+	newName := "http://" + svcName + "." + namespace + ":" + port
 
 	return newName, nil
 }


### PR DESCRIPTION
Fixes #220

## Description

The router port was hardcoded to `8088` in `GetRouterSvcUrl()`, which broke DruidIngestion for users who configured custom ports in their Druid CR.

This PR modifies the function to read the actual port from the discovered Kubernetes Service spec, with a fallback to the default port (8088) for backward compatibility.

## Key changed/added files in this PR

- `pkg/druidapi/druidapi.go`

## Testing

- [x] Tested locally on kind cluster with podman
- [x] Patched router service to use custom port 9999
- [x] Verified operator correctly reads port from service spec:
  - Default port (8088): `http://druid-tiny-cluster-routers.druid:8088/...` ✅
  - Custom port (9999): `http://druid-tiny-cluster-routers.druid:9999/...` ✅
- [x] Backward compatibility maintained - existing deployments work without changes
