### PR TITLE
Add flag to disable DruidIngestion controller

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=127.0.0.1:8080
             - --leader-elect
+            {{- if .Values.disableIngestionController }}
+            - --disable-ingestion-controller
+            {{- end }}
             {{- with .Values.extraArgs}}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -100,5 +100,8 @@ crd:
   enabled: true
   keep: true
 
+# Disable the DruidIngestion controller if the CRD is not installed
+disableIngestionController: false
+
 extraArgs: {}
   #- -zap-devel=false


### PR DESCRIPTION
Fixes #187

## Description

The operator fails to start if the DruidIngestion CRD is not installed, even when users only need the Druid CR functionality. This PR adds a `--disable-ingestion-controller` flag that allows the operator to run without requiring the DruidIngestion CRD.

## Key changed/added files in this PR

- `main.go` - Added `--disable-ingestion-controller` flag and conditional controller setup
- `chart/values.yaml` - Added `disableIngestionController: false` option
- `chart/templates/deployment.yaml` - Pass flag to operator when enabled

This PR has:

- [x] `helm lint ./chart` - passes
- [x] `helm template` - renders correctly with default values (flag not present)
- [x] `helm template --set disableIngestionController=true` - renders correctly with flag present
- [x] Tested locally without flag - operator shows CRD error as expected
- [x] Tested locally with flag - operator starts successfully with log message "DruidIngestion controller is disabled"
- [x] Verified backward compatibility - default behavior unchanged (flag is false by default)


## Usage

**Via Helm:**
```yaml
disableIngestionController: true