### PR TITLE
fix: make error output actually debuggable

### DIFF
--- a/controllers/ingestion/reconciler.go
+++ b/controllers/ingestion/reconciler.go
@@ -494,6 +494,15 @@ func (r *DruidIngestionReconciler) CreateOrUpdate(
 					v1.EventTypeNormal,
 					fmt.Sprintf("Resp [%s], Result [%s]", string(respUpdateSpec.ResponseBody), result),
 					DruidIngestionControllerPatchStatusSuccess)
+			} else {
+				// Non-200 response - log error and record event
+				build.Recorder.GenericEvent(
+					di,
+					v1.EventTypeWarning,
+					fmt.Sprintf("Failed to update spec, StatusCode [%d], Resp [%s]", respUpdateSpec.StatusCode, string(respUpdateSpec.ResponseBody)),
+					DruidIngestionControllerUpdateFail,
+				)
+				return controllerutil.OperationResultNone, fmt.Errorf("failed to update ingestion spec, status code: %d, response: %s", respUpdateSpec.StatusCode, string(respUpdateSpec.ResponseBody))
 			}
 
 		}


### PR DESCRIPTION
### Description

Debugging failures in this operator is pretty impossible without digging into druid itself. On non 200 the reconciler should at least output a log/event. Non 200 error codes just disappear in the current handling.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR

some logging
