### PR TITLE
Support configurable revisionHistoryLimit on the operator deployment

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -30,6 +30,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if hasKey .Values "revisionHistoryLimit" }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | int }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "druid-operator.selectorLabels" . | nindent 6 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -31,6 +31,8 @@ env:
 
 replicaCount: 1
 
+revisionHistoryLimit: 10 # Number of old ReplicaSets to retain for rollback
+
 image:
   repository: datainfrahq/druid-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
### Description

The operator Deployment doesn't set `revisionHistoryLimit`, so Kubernetes keeps 10 old ReplicaSets with no way to tune it from the chart. This adds an optional `revisionHistoryLimit` value. It's guarded by `hasKey` and defaults to 10 (the Kubernetes default), so existing installs render identically.

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `chart/templates/deployment.yaml`
 * `chart/values.yaml`